### PR TITLE
Update Sabre to work with the new get_state/set_state

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -63,8 +63,8 @@ fn run() -> Result<(), error::CliError> {
             (@arg payload: -p --payload +required +takes_value "Path to Sabre contract payload")
             (@arg key: -k --key +takes_value "Signing key name")
             (@arg url: --url +takes_value "URL to the Sawtooth REST API")
-            (@arg inputs: --inputs +takes_value "Input addresses used by the contract")
-            (@arg outputs: --outputs +takes_value "Output addresses used by the contract")
+            (@arg inputs: --inputs +takes_value +multiple "Input addresses used by the contract")
+            (@arg outputs: --outputs +takes_value +multiple"Output addresses used by the contract")
             (@arg wait: --wait +takes_value "A time in seconds to wait for batches to be committed")
         )
         (@subcommand ns =>
@@ -136,17 +136,12 @@ fn run() -> Result<(), error::CliError> {
         };
 
         let inputs = exec_matches
-            .value_of("inputs")
-            .unwrap_or("")
-            .split(":")
-            .map(|i| i.into())
-            .collect();
+            .values_of("inputs")
+            .map(|values| values.map(|v| v.into()).collect()).unwrap();
+
         let outputs = exec_matches
-            .value_of("outputs")
-            .unwrap_or("")
-            .split(":")
-            .map(|o| o.into())
-            .collect();
+            .values_of("outputs")
+            .map(|values| values.map(|v| v.into()).collect()).unwrap();
 
         let (name, version) = match contract.split(":").collect::<Vec<_>>() {
             ref v if (v.len() == 1 || v.len() == 2) && v[0].len() == 0 => Err(

--- a/integration/tests/test_sabre.rs
+++ b/integration/tests/test_sabre.rs
@@ -216,7 +216,7 @@ fn test_sabre() {
         };
     assert!(response["data"][0]["status"]=="COMMITTED");
 
-    // Test that Sabre will successfully try to execuet the contract but the smart contract will
+    // Test that Sabre will successfully try to execute the contract but the smart contract will
     // return an invalid transaction because A has already been state.
     //
     // Send ExecuteContractAction with the following:
@@ -237,7 +237,7 @@ fn test_sabre() {
     println!("{}", message);
     assert!(message.contains("Wasm contract returned invalid transaction"));
 
-    // Test that Sabre will successfully try to execuet the contract but the smart contract will
+    // Test that Sabre will successfully try to execute the contract but the smart contract will
     // return an invalid transaction because Bad does not exist in state.
     //
     // Send ExecuteContractAction with the following:

--- a/sdk/src/externs.rs
+++ b/sdk/src/externs.rs
@@ -19,6 +19,7 @@ pub type WasmPtrList = i32;
 extern "C" {
     pub fn get_state(addr: WasmPtr) -> WasmPtr;
     pub fn set_state(addr: WasmPtr, state: WasmPtr) -> i32;
+    pub fn delete_state(addresses: WasmPtrList) -> WasmPtrList;
     pub fn get_ptr_len(ptr: WasmPtr) -> isize;
     pub fn get_capacity_len(ptr: WasmPtr) -> isize;
     pub fn alloc(len: usize) -> WasmPtr;
@@ -26,4 +27,6 @@ extern "C" {
     pub fn write_byte(ptr: WasmPtr, offset: u32, byte: u8) -> i32;
     pub fn get_ptr_collection_len(ptr: WasmPtrList) -> isize;
     pub fn get_ptr_from_collection(ptr: WasmPtrList, index: u32) -> WasmPtr;
+    pub fn add_to_collection(head: WasmPtr, ptr: WasmPtr) -> WasmPtr;
+    pub fn create_collection(head: WasmPtr)-> WasmPtr;
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -11,12 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 extern crate protobuf;
 mod externs;
 
 use std::error::Error;
 use std::string::FromUtf8Error;
+use std::collections::HashMap;
 pub use externs::{WasmPtr, WasmPtrList};
 
 pub struct Header {
@@ -58,23 +58,38 @@ impl TransactionContext {
     pub fn new() -> TransactionContext {
         TransactionContext {}
     }
-    pub fn get_state(&self, address: &str) -> Result<Option<Vec<u8>>, WasmSdkError> {
+    pub fn get_state(&self, addresses: Vec<String>) -> Result<Option<Vec<u8>>, WasmSdkError> {
         unsafe {
-            let wasm_buffer = WasmBuffer::new(address.to_string().as_bytes())?;
-            ptr_to_vec(externs::get_state(wasm_buffer.into_raw()))
+            if addresses.is_empty(){
+                return Err(WasmSdkError::InvalidTransaction(
+                    "No address to delte".into(),
+                ));
+            }
+            let head = &addresses[0];
+            let header_address_buffer = WasmBuffer::new(head.as_bytes())?;
+            externs::create_collection(header_address_buffer.into_raw());
+
+            for addr in addresses[1..].iter() {
+                let wasm_buffer = WasmBuffer::new(addr.as_bytes())?;
+                externs::add_to_collection(
+                    header_address_buffer.into_raw(), wasm_buffer.into_raw());
+            };
+            ptr_to_vec(externs::get_state(header_address_buffer.into_raw()))
         }
     }
 
-    pub fn set_state(&self, address: &str, state: &[u8]) -> Result<(), WasmSdkError> {
-        unsafe {
-            let wasm_address_buffer = WasmBuffer::new(address.to_string().as_bytes())?;
-            let wasm_state_buffer = WasmBuffer::new(state)?;
-            ptr_to_vec(externs::set_state(
-                wasm_address_buffer.into_raw(),
-                wasm_state_buffer.into_raw(),
-            ))?;
-            Ok(())
+    pub fn set_state(&self,  entries: HashMap<String, Vec<u8>>) -> Result<(), WasmSdkError> {
+        for (address, state) in entries.iter() {
+            unsafe {
+                let wasm_address_buffer = WasmBuffer::new(address.to_string().as_bytes())?;
+                let wasm_state_buffer = WasmBuffer::new(&state)?;
+                ptr_to_vec(externs::set_state(
+                    wasm_address_buffer.into_raw(),
+                    wasm_state_buffer.into_raw(),
+                ))?;
+            }
         }
+        Ok(())
     }
 
     pub fn delete_state(&self, addresses: Vec<String>) -> Result<Option<Vec<String>>, WasmSdkError> {

--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::collections::HashMap;
+
 use protobuf;
 use protobuf::RepeatedField;
 
@@ -298,7 +300,7 @@ impl<'a> SabreState<'a> {
 
     pub fn get_admin_setting(&mut self) -> Result<Option<Setting>, ApplyError> {
         let address = get_sawtooth_admins_address()?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let setting: Setting = match protobuf::parse_from_bytes(packed.as_slice()) {
@@ -322,7 +324,7 @@ impl<'a> SabreState<'a> {
         version: &str,
     ) -> Result<Option<Contract>, ApplyError> {
         let address = make_contract_address(name, version)?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let contracts: ContractList = match protobuf::parse_from_bytes(packed.as_slice()) {
@@ -353,7 +355,7 @@ impl<'a> SabreState<'a> {
         new_contract: Contract,
     ) -> Result<(), ApplyError> {
         let address = make_contract_address(name, version)?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.to_string()])?;
         let mut contract_list = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(contracts) => contracts,
@@ -394,8 +396,10 @@ impl<'a> SabreState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }
@@ -424,7 +428,7 @@ impl<'a> SabreState<'a> {
         name: &str,
     ) -> Result<Option<ContractRegistry>, ApplyError> {
         let address = make_contract_registry_address(name)?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let contract_registries: ContractRegistryList =
@@ -455,7 +459,7 @@ impl<'a> SabreState<'a> {
         new_contract_registry: ContractRegistry,
     ) -> Result<(), ApplyError> {
         let address = make_contract_registry_address(name)?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.to_string()])?;
         let mut contract_registry_list = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(contract_registries) => contract_registries,
@@ -500,8 +504,10 @@ impl<'a> SabreState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }
@@ -530,7 +536,7 @@ impl<'a> SabreState<'a> {
         namespace: &str,
     ) -> Result<Option<NamespaceRegistry>, ApplyError> {
         let address = make_namespace_registry_address(namespace)?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let namespace_registries: NamespaceRegistryList =
@@ -560,7 +566,7 @@ impl<'a> SabreState<'a> {
         namespace: &str,
     ) -> Result<Option<NamespaceRegistryList>, ApplyError> {
         let address = make_namespace_registry_address(namespace)?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address])?;
         match d {
             Some(packed) => {
                 let namespace_registries: NamespaceRegistryList =
@@ -585,7 +591,7 @@ impl<'a> SabreState<'a> {
         new_namespace_registry: NamespaceRegistry,
     ) -> Result<(), ApplyError> {
         let address = make_namespace_registry_address(namespace)?;
-        let d = self.context.get_state(&address)?;
+        let d = self.context.get_state(vec![address.to_string()])?;
         let mut namespace_registry_list = match d {
             Some(packed) => match protobuf::parse_from_bytes(packed.as_slice()) {
                 Ok(namespace_registries) => namespace_registries,
@@ -630,8 +636,10 @@ impl<'a> SabreState<'a> {
                 )))
             }
         };
+        let mut sets = HashMap::new();
+        sets.insert(address, serialized);
         self.context
-            .set_state(&address, serialized.as_ref())
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
         Ok(())
     }


### PR DESCRIPTION
Also updates the cli to accept multiple inputs and outputs.

Adds delete_state to the sabre sdk.

This should not be merged until https://github.com/hyperledger/sawtooth-core/pull/1722 is merged into sawtooth core. 