### PR TITLE
Fetch git tags in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ node ('master') {
         ws("workspace/${env.BUILD_TAG}") {
             stage("Clone Repo") {
                 checkout scm
+                sh 'git fetch --tags'
             }
 
             if (!(env.BRANCH_NAME == 'master' && env.JOB_BASE_NAME == 'master')) {


### PR DESCRIPTION
Tags are required to get the dev version number and JJB multibranch
fetches without tags.

Signed-off-by: Richard Berg <rberg@bitwise.io>