### PR TITLE
Fixups to the build system

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,10 +81,8 @@ node ('master') {
             }
 
             stage ("Build documentation") {
-                sh 'cd docs'
-                sh 'docker-compose up'
-                sh 'docker-compose down'
-                sh 'cd ..'
+                sh 'docker-compose -f docs/docker-compose.yaml up'
+                sh 'docker-compose -f docs/docker-compose.yaml down'
             }
 
             stage("Archive Build artifacts") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,8 +87,8 @@ node ('master') {
 
             stage("Archive Build artifacts") {
                 sh 'mkdir -p build/debs'
-                sh 'docker run --rm -v $(pwd)/build/debs:/build/debs sawtooth-sabre-cli:${ISOLATION_ID} bash -c "cp /tmp/*.deb /build/debs"'
-                sh 'docker run --rm -v $(pwd)/build/debs:/build/debs sawtooth-sabre-tp:${ISOLATION_ID} bash -c "cp /tmp/*.deb /build/debs"'
+                sh 'docker run --rm -v $(pwd)/build/debs:/build/debs --entrypoint "/bin/bash" sawtooth-sabre-cli:${ISOLATION_ID} "-c" "cp /tmp/*.deb /build/debs"'
+                sh 'docker run --rm -v $(pwd)/build/debs:/build/debs --entrypoint "/bin/bash" sawtooth-sabre-tp:${ISOLATION_ID} "-c" "cp /tmp/*.deb /build/debs"'
                 archiveArtifacts artifacts: '*.tgz, *.zip'
                 archiveArtifacts artifacts: 'build/debs/*.deb'
                 archiveArtifacts artifacts: 'docs/build/html/**'

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -20,6 +20,9 @@ services:
     container_name: sabre-docs
     volumes:
       - ..:/project
+    build:
+      context: .
+      dockerfile: Dockerfile
     entrypoint: "bash -c \"\
       cd /project/cli && \
       cargo build && \
@@ -27,5 +30,3 @@ services:
       ./bin/generate_cli_output && \
       make html
       \""
-    build:
-      context: .


### PR DESCRIPTION
Jenkins runs each sh command in a separate sub-shell, this caused the
wrong docker-compose file to run during the "Build documentation" stage.

Signed-off-by: Richard Berg <rberg@bitwise.io>