### PR TITLE
Run tutorial in installed mode and docs updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ node ('master') {
             // environment doesn't need all the dependencies.
 
             stage("Build Sabre") {
-                sh 'docker-compose -f docker-compose-installed.yaml build shell'
+                sh 'docker-compose -f docker-compose-installed.yaml build sabre-cli'
                 sh 'docker-compose -f docker-compose-installed.yaml build sabre-tp'
             }
 

--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -18,6 +18,8 @@ services:
   validator:
     image: hyperledger/sawtooth-validator:1.0
     container_name: sabre-validator
+    volumes:
+      - .:/project
     expose:
       - 9704
     ports:
@@ -26,8 +28,14 @@ services:
         bash -c "
         sawadm keygen &&
         sawtooth keygen &&
-        sawset genesis &&
-        sawadm genesis config-genesis.batch &&
+        mkdir -p /project/keys && \
+        cp /root/.sawtooth/keys/* /project/keys &&
+        sawset genesis -k /etc/sawtooth/keys/validator.priv &&
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.swa.administrators=$$(cat project/keys/root.pub) \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator -vv \
           --endpoint tcp://validator:9705 \
           --bind component:tcp://eth0:9704 \
@@ -44,10 +52,7 @@ services:
     entrypoint: sawtooth-rest-api --connect tcp://validator:9704 --bind rest-api:9708 -vv
 
   shell:
-    build:
-      context: .
-      dockerfile: cli/Dockerfile-installed
-    image: sawtooth-sabre-cli:${ISOLATION_ID}
+    image: hyperledger/sawtooth-all:1.0
     container_name: sabre-shell
     entrypoint: |
         bash -c "
@@ -69,3 +74,14 @@ services:
     depends_on:
       - validator
     entrypoint: sawtooth-sabre -vv --connect tcp://validator:9704
+
+  sabre-cli:
+    build:
+      context: .
+      dockerfile: cli/Dockerfile-installed
+    image: sawtooth-sabre-cli:${ISOLATION_ID}
+    container_name: sabre-cli
+    volumes:
+      - .:/project
+      - ./keys:/root/.sawtooth/keys
+    entrypoint: tail -f /dev/null

--- a/docs/source/application_developer_guide.rst
+++ b/docs/source/application_developer_guide.rst
@@ -15,7 +15,7 @@ guide will use an example smart contract called intkey-multiply. This smart
 contract will take intkey values, multiply them, and store the new intkey key
 value pair in the intkey state.
 
-.. note: This guide assumes familiarity with Sawtooth Transaction Processors
+.. note:: This guide assumes familiarity with Sawtooth Transaction Processors
   and that cargo/rust is already installed.
 
 .. _writing-sabre-sm-label:

--- a/docs/source/sabre_cli.rst
+++ b/docs/source/sabre_cli.rst
@@ -8,8 +8,8 @@ and their permissions.
 
 sabre
 =====
-``sabre`` is the top level command for Sabre and it contains 4 subcommands.
-Theses commands are ``upload``, ``ns``, ``perm``, and ``exec``. The subcommands
+``sabre`` is the top level command for Sabre. It contains the following
+subcommands: ``cr``, ``upload``, ``ns``, ``perm``, and ``exec``. The subcommands
 have options and arguments that control their behavior. All subcommands include
 ``-key``, the name of the signing key, and ``--url``, the url to the Sawtooth
 REST API.
@@ -60,7 +60,7 @@ following information:
   outputs:
     - <output addresses>
 
-Note only an owner of the associated contract registry is allowed to upload
+Only an owner of the associated contract registry is allowed to upload
 a new version of a contract.
 
 sabre ns

--- a/docs/source/sabre_transaction_family.rst
+++ b/docs/source/sabre_transaction_family.rst
@@ -102,9 +102,10 @@ Contract
 --------
 
 A Contract represents the Sabre smart contract. It is uniquely
-identified by its name and version number. The contract also contains the
-expected inputs and outputs used when executing the contract, the public
-key of the creator, and the compiled wasm code of the contract.
+identified by its name and version number. The contract also contains
+the expected inputs and outputs (namespaces) used when executing the
+contract, the public key of the creator, and the compiled wasm code of
+the contract.
 
 .. code-block:: protobuf
 
@@ -283,6 +284,14 @@ The outputs for CreateContractAction must include:
 * the address for the new contract
 * the address for the contract registry
 
+.. note:: These inputs/outputs are for the general Sawtooth transaction.
+   They are required for any transaction, whether it is a Sabre
+   transaction or a transaction of any other transaction family.
+   However, the inputs/outputs fields in the ``CreateContractAction``,
+   above,  are not related to the ones listed in the Sawtooth
+   transaction. The ``CreateContractAction`` inputs/outputs are
+   used to enforce namespace permissions for the contract.
+
 
 DeleteContractAction
 --------------------
@@ -339,7 +348,9 @@ or output is less than 6 characters the transaction is invalid. For every
 input, the namespace registry must have a read permission for the contract and
 for every output the namespace registry must have a write permission for the
 contract. If either are missing or the namespace registry does not exist,
-the transaction is invalid.
+the transaction is invalid. The inputs and outputs in the
+``ExecuteContractAction`` payload shall not be mistaken with the inputs and
+outputs of the Sawtooth transaction carrying the payload.
 
 The contract is then loaded into the wasm interpreter and run against the
 provided payload. A result is returned. If the result is 1 the transaction

--- a/example/intkey_multiply/processor/src/handler.rs
+++ b/example/intkey_multiply/processor/src/handler.rs
@@ -97,7 +97,7 @@ fn decode_intkey(hex_string: String) -> Result<BTreeMap<String, u32>, ApplyError
 
     // First two characters should be A followed by the number of elements.
     // Only check for A as this will be a map with 15 or less elements
-    // It is unlikley that an address will have that many hash collisons.
+    // It is unlikely that an address will have that many hash collisions.
     let data_type = hex_string.get(..1)
         .ok_or_else(|| ApplyError::InvalidTransaction("Unable to get data type".into()))?;
     if data_type != "A" {
@@ -108,7 +108,7 @@ fn decode_intkey(hex_string: String) -> Result<BTreeMap<String, u32>, ApplyError
 
     let entries_hex = hex_string.get(1..2)
         .ok_or_else(|| ApplyError::InvalidTransaction(
-            "Unable to get number of entires in the map".into()))?;
+            "Unable to get number of entries in the map".into()))?;
 
     let entries  = u32::from_str_radix(entries_hex, 16)
         .map_err(|err| ApplyError::InvalidTransaction(
@@ -131,7 +131,7 @@ fn decode_intkey(hex_string: String) -> Result<BTreeMap<String, u32>, ApplyError
         // cannot be empty and must not be greater than 20 characters
         if string_type < 97 || string_type > 116 {
             return Err(ApplyError::InvalidTransaction(String::from(
-                "Name is either to long, to short, or not a string.",
+                "Name is either too long, too short, or not a string.",
             )))
         }
         start = start + 2;
@@ -158,7 +158,7 @@ fn decode_intkey(hex_string: String) -> Result<BTreeMap<String, u32>, ApplyError
 
         start = start + 2;
         // For number less than 23 (decimal) the first two bytes represent the number. If it is
-        // greater than 23 the first two bytes represent the number of digits requreid to
+        // greater than 23 the first two bytes represent the number of digits required to
         // calculate the value followed by the actual bytes for the number.
         if number > 23 {
             number = number - 23;
@@ -209,7 +209,7 @@ fn decode_intkey(hex_string: String) -> Result<BTreeMap<String, u32>, ApplyError
 fn encode_intkey(map: BTreeMap<String, u32>) -> Result<String, ApplyError> {
     // First two characters should be A followed by the number of elements.
     // Only check for A as this will be a map with 15 or less elements
-    // It is unlikley that an address will have that many hash collisons
+    // It is unlikely that an address will have that many hash collisions
     let mut hex_string = "A".to_string();
     let map_length = map.len() as u32;
     hex_string = hex_string + &format!("{:X}", map_length);

--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -1082,7 +1082,7 @@ fn create_contract(
 
     if !contract_registry.owners.contains(&signer.into()) {
         return Err(ApplyError::InvalidTransaction(format!(
-            "Only owners can submit new versions of contracts {}",
+            "Only owners can submit new versions of contracts: {}",
             signer,
         )))
     }


### PR DESCRIPTION
This PR updates the docker-compose-installed.yaml file to be able to run the tutorial of the documentation in `installed` mode. It makes it closer to the non-installed docker-compose.yaml file. The PR also includes separate commits for some minor documentation revisions and typos in comments or error message in rust files.