### PR TITLE
Update build.rs files to use Customize::default()

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -25,9 +25,7 @@ fn main() {
         out_dir: "src/protos",
         input: &["../protos/payload.proto"],
         includes: &["../protos"],
-        customize: Customize {
-            ..Default::default()
-        }
+        customize: Customize::default(),
     }).expect("protoc");
 
     let mut file = File::create("src/protos/mod.rs").unwrap();

--- a/tp/build.rs
+++ b/tp/build.rs
@@ -30,9 +30,7 @@ fn main() {
             "../protos/contract.proto",
         ],
         includes: &["../protos"],
-        customize: Customize {
-            ..Default::default()
-        }
+        customize: Customize::default(),
     }).expect("protoc");
 
     let mut file = File::create("src/protos/mod.rs").unwrap();


### PR DESCRIPTION
Protobuf updated and removed Default::default() and
instead we need to use Customize::default()

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>

Note sabre will not build until sawtooth core is updated. 