### PR TITLE
Fix ambiguity in License label.

### DIFF
--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.3"
 description = "Sawtooth Sabre Transaction Processor"
 authors = ["Cargill Incorporated"]
 build = "build.rs"
-license="Apache"
+license="Apache-2.0"
 
 [package.metadata.deb]
 extended-description= """\


### PR DESCRIPTION
Update Cargo.toml to explicitly list Apache 2.0 rather than just Apache.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>