### PR TITLE
Fix DeleteContractRegistryAction inputs/outputs

### DIFF
--- a/docs/source/sabre_transaction_family.rst
+++ b/docs/source/sabre_transaction_family.rst
@@ -417,11 +417,11 @@ The contract registry is deleted.
 The inputs for DeleteContractRegistryAction must include:
 
 * the address for the contract registry
+* the settings address for ``sawtooth.swa.administrators``
 
 The outputs for DeleteContractRegistryAction must include:
 
 * the address for the contract registry
-* the settings address for ``sawtooth.swa.administrators``
 
 UpdateContractRegistryOwnersAction
 ----------------------------------


### PR DESCRIPTION
Corrected the Sabre Transaction Family documentation:
sawtooth.swa.administrators is an input (not output).

Signed-off-by: Anne Chenette <chenette@bitwise.io>