### PR TITLE
Update Running a Sabre Smart Contract doc

### DIFF
--- a/docs/source/sabre_transaction_family.rst
+++ b/docs/source/sabre_transaction_family.rst
@@ -58,6 +58,8 @@ address in a NamespaceRegistryList
     repeated NamespaceRegistry registries = 1;
   }
 
+.. _TPdoc-ContractRegistry-label:
+
 ContractRegistry
 ----------------
 ContractRegistry keeps track of versions of the Sabre contract and the list of


### PR DESCRIPTION
Rewrite to expand, clarify, update, edit, and format information. Changes include:

- Rewrite throughout to clarify information, make consistent with procedures in
  the Sawtooth core docs, and format as a procedure

- Add introduction and prerequisites sections

- Summarize what the Docker Compose files do (describe containers, key generation,
  Sawtooth administrator setting, and volume setup/key sharing between containers)

- Consistently show which container is used for each step

- Clarify that "sabre upload" uploads a contract definition file (not a
  contract) and that "sabre ns" creates a namespace registry (not a namespace)

- Update the example contract definition file, with explanations of the Sabre
  and Pike namespaces (in source but not shown in the previous doc)

- Delete hard-coded, out-of-date CLI help; replace with info on running the
  command with the --help option

- Summarize what items must be in place before running "sabre exec"

- Add final step to shut down the Sawtooth Sabre environment

Signed-off-by: Anne Chenette <chenette@bitwise.io>