### PR TITLE
Add an apt-get upgrade to address a series of High risk CVE's discovered.

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/proto
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
  && rm protoc-3.5.1-linux-x86_64.zip
 
-RUN apt-get update && apt-get install -y protobuf-compiler
+RUN apt-get update && apt-get install -y protobuf-compiler && apt-get upgrade -y
 
 WORKDIR /project/cli
 ENV PATH=$PATH:/project/cli/target/debug/

--- a/cli/Dockerfile-installed
+++ b/cli/Dockerfile-installed
@@ -55,6 +55,6 @@ COPY --from=sabre-cli-builder /project/cli/target/debian/sabre-cli*.deb /tmp
 
 RUN apt-get update \
  && dpkg -i /tmp/sabre-cli_*.deb || true \
- && apt-get -f -y install
+ && apt-get -f -y install && apt-get upgrade -y 
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Running Anchore scans versus the installed docker images turned up some high risk vulnerabilities.  This will usually prevent the images being deployed in any highly locked down environments. 

Signed-off-by: Kevin O'Donnell <kodonnel@gmail.com>