### PR TITLE
Increase Sabre version to 0.2

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sabre-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Cargill Incorporated"]
 build = "build.rs"
 

--- a/example/intkey_multiply/cli/Cargo.toml
+++ b/example/intkey_multiply/cli/Cargo.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 [package]
 name = "intkey-multiply-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Cargill Incorporated"]
 
 [[bin]]

--- a/example/intkey_multiply/processor/Cargo.toml
+++ b/example/intkey_multiply/processor/Cargo.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 [package]
 name = "intkey-multiply"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Cargill Incorporated"]
 build = "build.rs"
 

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Cargill Incorporated"]
 
 [dev-dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "sabre-sdk"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Cargill, Incorporated"]
 license = "Apache-2.0"
 description = """\

--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sawtooth-sabre"
-version = "0.1.0"
+version = "0.2.0"
 description = "Sawtooth Sabre Transaction Processor"
 authors = ["Cargill Incorporated"]
 build = "build.rs"


### PR DESCRIPTION
Sabre is going to be updated to work with the
newer version of the Sawtooth Rust SDK. As such
the version needs to be increased because it will
no longer be compatible with 0.1 version of Sabre.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>