### PR TITLE
BACKPORT: Add Missing Isolation ID to docker compose files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
     stop_signal: SIGKILL
 
   sabre-tp:
-    image: sabre-tp
+    image: sabre-tp:${ISOLATION_ID}
     container_name: sabre-tp
     entrypoint: "bash -c \"\
         cd /project/tp/ && \
@@ -89,7 +89,7 @@ services:
       context: tp
 
   sabre-cli:
-    image: sabre-cli
+    image: sabre-cli:${ISOLATION_ID}
     container_name: sabre-cli
     volumes:
       - .:/project

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -16,7 +16,7 @@ version: "2.1"
 
 services:
   sabre-docs:
-    image: sabre-docs
+    image: sabre-docs:${ISOLATION_ID}
     container_name: sabre-docs
     volumes:
       - ..:/project

--- a/integration/sabre_test.yaml
+++ b/integration/sabre_test.yaml
@@ -33,7 +33,7 @@ services:
         \""
 
   build_intkey_multiply:
-    image:  build_intkey_multiply
+    image:  build_intkey_multiply:${ISOLATION_ID}
     container_name: build_intkey_multiply
     volumes:
       - .:/project
@@ -45,7 +45,7 @@ services:
       context: integration
 
   build_pike:
-    image:  build_pike
+    image:  build_pike:${ISOLATION_ID}
     container_name: build_pike
     volumes:
       - .:/project
@@ -58,7 +58,7 @@ services:
       context: integration
 
   build_intkey:
-    image:  build_intkey
+    image:  build_intkey:${ISOLATION_ID}
     container_name: build_intkey
     volumes:
       - .:/project
@@ -72,7 +72,7 @@ services:
 
 
   test_sabre:
-    image: test_sabre:ISOLATION_ID
+    image: test_sabre:${ISOLATION_ID}
     container_name: test_sabre
     depends_on:
       - rest-api


### PR DESCRIPTION
This will fix an issue with colliding images when
running the build in Jenkins.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>