### PR TITLE
Split Sabre TP into a library and a binary

### DIFF
--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -25,6 +25,14 @@ conf-files = [
     "/etc/default/sawtooth-sabre"
 ]
 
+[lib]
+name = "sawtooth_sabre"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sawtooth-sabre"
+path = "src/main.rs"
+
 [dependencies]
 sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 log = "0.3.8"

--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -830,7 +830,11 @@ fn delete_namespace_registry_permission(
     state.set_namespace_registry(namespace, namespace_registry)
 }
 
-pub fn is_admin(signer: &str, org_id: &str, state: &mut SabreState) -> Result<(), ApplyError> {
+pub(crate) fn is_admin(
+    signer: &str,
+    org_id: &str,
+    state: &mut SabreState,
+) -> Result<(), ApplyError> {
     let admin = match state.get_agent(signer) {
         Ok(None) => {
             return Err(ApplyError::InvalidTransaction(format!(

--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Provides a Sawtooth Transaction Handler for executing Sabre transactions.
+
 use crypto::digest::Digest;
 use crypto::sha2::Sha512;
 use protobuf::RepeatedField;
@@ -45,6 +47,15 @@ const CONTRACT_REGISTRY_PREFIX: &'static str = "00ec01";
 /// The contract prefix for global state (00ec02)
 const CONTRACT_PREFIX: &'static str = "00ec02";
 
+/// Handles Sabre Transactions
+///
+/// This handler implements the Sawtooth TransactionHandler trait, in order to execute Sabre
+/// transaction payloads.  These payloads include on-chain smart contracts executed in a
+/// WebAssembly virtual machine.
+///
+/// WebAssembly (Wasm) is a stack-based virtual machine newly implemented in major browsers. It is
+/// well-suited for the purposes of smart contract execution due to its sandboxed design, growing
+/// popularity, and tool support.
 pub struct SabreTransactionHandler {
     family_name: String,
     family_versions: Vec<String>,
@@ -52,6 +63,7 @@ pub struct SabreTransactionHandler {
 }
 
 impl SabreTransactionHandler {
+    /// Constructs a new SabreTransactionHandler
     pub fn new() -> SabreTransactionHandler {
         SabreTransactionHandler {
             family_name: "sabre".into(),

--- a/tp/src/lib.rs
+++ b/tp/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate log;
+
+mod addressing;
+pub mod handler;
+mod payload;
+mod protos;
+mod state;
+mod wasm_executor;

--- a/tp/src/main.rs
+++ b/tp/src/main.rs
@@ -14,18 +14,10 @@
 
 #[macro_use]
 extern crate clap;
-#[macro_use]
-extern crate log;
 
-mod addressing;
-mod handler;
-mod payload;
-mod protos;
-mod state;
-mod wasm_executor;
-
-use handler::SabreTransactionHandler;
 use log::LogLevel;
+
+use sawtooth_sabre::handler::SabreTransactionHandler;
 use sawtooth_sdk::processor::TransactionProcessor;
 
 fn main() {


### PR DESCRIPTION
Split the transaction processor and handler into a binary and library outputs.  This enables the use of the sabre transaction processor from within other embedded contexts (for example, using [Transact](https://github.com/bitwiseio/transact))