### PR TITLE
Replace unix with not wasm32 in platform-specific dependencies

### DIFF
--- a/contracts/sawtooth-pike/tp/Cargo.toml
+++ b/contracts/sawtooth-pike/tp/Cargo.toml
@@ -28,7 +28,7 @@ addresser = {path = "../addresser"}
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = {path = "../../../sdk"}
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 log = "0.3.8"
 log4rs = "0.7.0"

--- a/docs/source/application_developer_guide.rst
+++ b/docs/source/application_developer_guide.rst
@@ -94,7 +94,7 @@ dependencies for the smart contract, and dependencies used by both.
 Dependencies used by both should remain under ``[dependencies]``, while smart
 contract dependencies should go under the
 ``[target.'cfg(target_arch = "wasm32")'.dependencies]`` and transaction processors
-dependencies should go under ``[target.'cfg(unix)'.dependencies]``.
+dependencies should go under ``[target.'cfg(not(target_arch = "wasm32"))'.dependencies]``.
 
 The following is an example for intkey-multiply
 
@@ -115,7 +115,7 @@ The following is an example for intkey-multiply
   rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
   sabre-sdk = {path = "../../../sdk"}
 
-  [target.'cfg(unix)'.dependencies]
+  [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
   rust-crypto = "0.2.36"
   sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
   rustc-serialize = "0.3.22"

--- a/example/intkey_multiply/processor/Cargo.toml
+++ b/example/intkey_multiply/processor/Cargo.toml
@@ -27,7 +27,7 @@ hex = "0.3.1"
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = {path = "../../../sdk"}
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2.36"
 sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 rustc-serialize = "0.3.22"


### PR DESCRIPTION
This will allow sabre smart contracts to be compiled on more
platforms when not compiling into wasm.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>

Add the wasm32 target rustup target add wasm32-unknown-unknown --toolchain nightly and run both cargo build and cargo +nightly build --target wasm32-unknown-unknown (in the respective directories). Both should pass.