### PR TITLE
Update Sabre family version to 0.2

### DIFF
--- a/cli/src/transaction.rs
+++ b/cli/src/transaction.rs
@@ -38,8 +38,8 @@ use protos::payload::SabrePayload_Action as Action;
 /// The Sawtooth Sabre transaction family name (sabre)
 const SABRE_FAMILY_NAME: &'static str = "sabre";
 
-/// The Sawtooth Sabre transaction family version (0.0)
-const SABRE_FAMILY_VERSION: &'static str = "0.0";
+/// The Sawtooth Sabre transaction family version (0.2)
+const SABRE_FAMILY_VERSION: &'static str = "0.2";
 
 /// The namespace registry prefix for global state (00ec00)
 const NAMESPACE_REGISTRY_PREFIX: &'static str = "00ec00";

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to Sabre's documentation!
     application_developer_guide.rst
     sabre_cli.rst
     smart_permissions.rst
+    version_compatibility.rst
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/version_compatibility.rst
+++ b/docs/source/version_compatibility.rst
@@ -1,0 +1,39 @@
+****************************************
+Sabre and Sawtooth Version Compatibility
+****************************************
+
+The following table shows the compatible versions of the Sabre transaction
+processor, Sabre SDK, and Sawtooth Rust SDK. It also shows the Docker tag for
+the Sabre transaction processor image.
+
+ - The Sabre transaction processor versions are
+   the versions used as part of the transaction processor’s registration.
+
+ - The Sabre SDK versions are the Crate versions of the Rust library that should
+   be set in the Cargo.toml file.
+
+ - The Docker tag is the tag that should be used for the
+   hyperledger/sawtooth-sabre-tp image if including in a docker-compose yaml
+   file.
+
+ - The Sawtooth Rust SDK versions are the Crate versions of the Rust library
+   that should be set in the Cargo.toml file.
+
++------------+----------+-----------+---------+--------------------------------+
+| Sabre      | Sabre SDK| Docker Tag| Sawtooth| Changes                        |
+| Transaction|          |           | Rust SDK|                                |
+| Processor  |          |           |         |                                |
++============+==========+===========+=========+================================+
+| 0.0        | 0.1      | 0.1       |  0.2    |                                |
+|            |          |           |         |                                |
+|            |          |           |         |                                |
++------------+----------+-----------+---------+--------------------------------+
+| 0.2        | 0.2      | 0.2       |  0.3    | - Transaction context is a     |
+|            |          |           |         |   trait                        |
+|            |          |           |         | - API has new get_state_entry  |
+|            |          |           |         |   to get one entry and         |
+|            |          |           |         |   get_state_entries to get     |
+|            |          |           |         |   multiple entries (plus       |
+|            |          |           |         |   corresponding functions for  |
+|            |          |           |         |   set and delete)              |
++------------+----------+-----------+---------+--------------------------------+

--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -67,7 +67,7 @@ impl SabreTransactionHandler {
     pub fn new() -> SabreTransactionHandler {
         SabreTransactionHandler {
             family_name: "sabre".into(),
-            family_versions: vec!["0.0".into()],
+            family_versions: vec!["0.2".into()],
             namespaces: vec![
                 NAMESPACE_REGISTRY_PREFIX.into(),
                 CONTRACT_REGISTRY_PREFIX.into(),


### PR DESCRIPTION
Updates the version of the Sabre family version to
0.2. This will allow someone to run both the 0.0 and
0.2 version of the Sabre TP on the same network.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>