### PR TITLE
Add no-op logging macros to the Sabre SDK

### DIFF
--- a/docs/source/application_developer_guide.rst
+++ b/docs/source/application_developer_guide.rst
@@ -134,6 +134,7 @@ the handler a public module and add an empty main function.
 
   cfg_if! {
       if #[cfg(target_arch = "wasm32")] {
+          #[macro_use]
           extern crate sabre_sdk;
       } else {
           #[macro_use]

--- a/docs/source/application_developer_guide.rst
+++ b/docs/source/application_developer_guide.rst
@@ -121,7 +121,6 @@ The following is an example for intkey-multiply
   rustc-serialize = "0.3.22"
   log = "0.3.0"
   log4rs = "0.7.0"
-  sawtooth-zmq = "0.8.2-dev5"
 
 
 The main.rs file for the transaction processor should separate out the

--- a/example/intkey_multiply/processor/Cargo.toml
+++ b/example/intkey_multiply/processor/Cargo.toml
@@ -33,7 +33,6 @@ sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
 rustc-serialize = "0.3.22"
 log = "0.3.0"
 log4rs = "0.7.0"
-sawtooth-zmq = "0.8.2-dev5"
 
 
 [build-dependencies]

--- a/example/intkey_multiply/processor/src/handler.rs
+++ b/example/intkey_multiply/processor/src/handler.rs
@@ -534,7 +534,6 @@ impl TransactionHandler for IntkeyMultiplyTransactionHandler {
             }
         };
         let mut state = IntkeyState::new(context);
-        #[cfg(not(target_arch = "wasm32"))]
         info!(
             "payload: {} {} {} {} {}",
             payload.get_name_a(),

--- a/example/intkey_multiply/processor/src/handler.rs
+++ b/example/intkey_multiply/processor/src/handler.rs
@@ -549,13 +549,12 @@ impl TransactionHandler for IntkeyMultiplyTransactionHandler {
         #[cfg(target_arch = "wasm32")]
         let result = match state.get_agent(signer)? {
             Some(agent) => {
-                run_smart_permisson(signer, request.get_payload(), agent)
-                    .map_err(|err| {
-                        ApplyError::InvalidTransaction(format!(
-                            "Unable to run smart permission: {}",
-                            err
-                        ))
-                    })
+                run_smart_permisson(signer, request.get_payload(), agent).map_err(|err| {
+                    ApplyError::InvalidTransaction(format!(
+                        "Unable to run smart permission: {}",
+                        err
+                    ))
+                })
             }
             // If the signer is not an agent, return okay.
             None => Ok(1),
@@ -618,11 +617,7 @@ impl TransactionHandler for IntkeyMultiplyTransactionHandler {
     }
 }
 #[cfg(target_arch = "wasm32")]
-fn run_smart_permisson(
-    signer: &str,
-    payload: &[u8],
-    agent: Agent,
-) -> Result<i32, ApplyError> {
+fn run_smart_permisson(signer: &str, payload: &[u8], agent: Agent) -> Result<i32, ApplyError> {
     let org_id = agent.get_org_id();
     let smart_permission_addr = compute_smart_permission_address(org_id, "test");
 

--- a/example/intkey_multiply/processor/src/handler.rs
+++ b/example/intkey_multiply/processor/src/handler.rs
@@ -157,7 +157,7 @@ fn decode_intkey(hex_string: String) -> Result<BTreeMap<String, u32>, ApplyError
         // calculate the value followed by the actual bytes for the number.
         if number > 23 {
             number = number - 23;
-            let mut value = match number {
+            let value = match number {
                 // two bytes
                 1 => {
                     let value = hex_string.get(start..start + 2).ok_or_else(|| {

--- a/example/intkey_multiply/processor/src/main.rs
+++ b/example/intkey_multiply/processor/src/main.rs
@@ -16,6 +16,7 @@ extern crate cfg_if;
 extern crate hex;
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
+        #[macro_use]
         extern crate sabre_sdk;
     } else {
         #[macro_use]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -14,6 +14,7 @@
 extern crate protobuf;
 
 mod externs;
+pub mod log;
 
 pub use externs::{WasmPtr, WasmPtrList};
 use std::collections::HashMap;

--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -1,0 +1,46 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The following are no-op log macros that will be used when running a smart contract in
+//! Sabre.
+
+#[macro_export]
+macro_rules! log {
+    ($lvl:expr, $($arg:tt)+) => {};
+}
+
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => {};
+}
+
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {};
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {};
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {};
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {};
+}


### PR DESCRIPTION
Logging does not currently compile into wasm. With these
macros a developer can write a log statement in a smart contract
that will be run normally if compiled into a transaction processor
and ignored in wasm code.

Before it was required to include the following above the log
statement:

`#[cfg(not(target_arch = "wasm32"))]`