### PR TITLE
Add dyn to trait objects

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -56,7 +56,7 @@ impl StdError for CliError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             CliError::UserError(ref _s) => None,
             CliError::IoError(ref err) => Some(err.borrow()),

--- a/contracts/sawtooth-pike/cli/src/error.rs
+++ b/contracts/sawtooth-pike/cli/src/error.rs
@@ -46,7 +46,7 @@ impl StdError for CliError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             CliError::UserError(ref _s) => None,
             CliError::IoError(ref err) => Some(err.borrow()),

--- a/example/intkey_multiply/cli/src/error.rs
+++ b/example/intkey_multiply/cli/src/error.rs
@@ -42,7 +42,7 @@ impl StdError for CliError {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             CliError::UserError(ref _s) => None,
             CliError::IoError(ref err) => Some(err.borrow()),

--- a/example/intkey_multiply/processor/src/handler.rs
+++ b/example/intkey_multiply/processor/src/handler.rs
@@ -340,12 +340,12 @@ impl IntkeyPayload {
 }
 
 pub struct IntkeyState<'a> {
-    context: &'a mut TransactionContext,
+    context: &'a mut dyn TransactionContext,
     get_cache: HashMap<String, BTreeMap<String, u32>>,
 }
 
 impl<'a> IntkeyState<'a> {
-    pub fn new(context: &'a mut TransactionContext) -> IntkeyState {
+    pub fn new(context: &'a mut dyn TransactionContext) -> IntkeyState {
         IntkeyState {
             context,
             get_cache: HashMap::new(),


### PR DESCRIPTION
Fix following nightly warning:

trait objects without an explicit `dyn` are deprecated

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>