### PR TITLE
 Add logging to Sabre SDK and wasm externals

### DIFF
--- a/docs/source/application_developer_guide.rst
+++ b/docs/source/application_developer_guide.rst
@@ -104,6 +104,7 @@ The following is an example for intkey-multiply
   name = "intkey-multiply"
   version = "0.1.0"
   authors = ["Cargill Incorporated"]
+  edition = "2018"
 
   [dependencies]
   clap = "2"
@@ -139,11 +140,8 @@ the handler a public module and add an empty main function.
       } else {
           #[macro_use]
           extern crate clap;
-          extern crate log4rs;
           #[macro_use]
           extern crate log;
-          extern crate rustc_serialize;
-          extern crate sawtooth_sdk;
           use std::process;
           use log::LogLevelFilter;
           use log4rs::append::console::ConsoleAppender;

--- a/docs/source/application_developer_guide.rst
+++ b/docs/source/application_developer_guide.rst
@@ -196,7 +196,10 @@ decorator, so they will only be compiled when compiling into Wasm.
       let handler = IntkeyMultiplyTransactionHandler::new();
       match handler.apply(request, context) {
           Ok(_) => Ok(true),
-          Err(err) => Err(err)
+          Err(err) => {
+              info!("{}", err);
+              Err(err)
+          }
       }
 
   }
@@ -219,6 +222,51 @@ decorator, so they will only be compiled when compiling into Wasm.
 
 For the full intkey-multiply example look at
 sawtooth-sabre/example/intkey_multiply/processor
+
+
+.. _logging-in-smart-contracts:
+
+Logging in a Sabre Smart Contract
+=================================
+The Sabre SDK provides log macros that match the provided log macros from the
+`log crate <https://doc.rust-lang.org/1.1.0/log/macro.info!.html>`_. To use add
+``#[macro_use]`` above ``extern crate sabre_sdk`` and use the macros as normal.
+
+.. code-block:: rust
+
+  info!(
+      "payload: {} {} {}",
+      payload.get_name_a(),
+      payload.get_name_b(),
+      payload.get_name_c()
+  );
+
+For debugging purposes, add a log statement to the final match statement in
+the apply method:
+
+.. code-block::
+
+  #[cfg(target_arch = "wasm32")]
+  // Sabre apply must return a bool
+  fn apply(
+      request: &TpProcessRequest,
+      context: &mut dyn TransactionContext,
+  ) -> Result<bool, ApplyError> {
+
+      let handler = IntkeyMultiplyTransactionHandler::new();
+      match handler.apply(request, context) {
+          Ok(_) => Ok(true),
+          Err(err) => {
+              info!("{}", err);
+              Err(err)
+          }
+      }
+
+  }
+
+The log level of the Sabre transaction processor is enforced for all smart
+contracts. For example, if the Sabre transaction processor has a log level of
+``info`` a ``debug`` statement in a smart contract will not be logged.
 
 .. _compiling-smart-contract-label:
 

--- a/example/intkey_multiply/processor/src/handler.rs
+++ b/example/intkey_multiply/processor/src/handler.rs
@@ -533,12 +533,10 @@ impl TransactionHandler for IntkeyMultiplyTransactionHandler {
         };
         let mut state = IntkeyState::new(context);
         info!(
-            "payload: {} {} {} {} {}",
+            "payload: {} {} {}",
             payload.get_name_a(),
             payload.get_name_b(),
-            payload.get_name_c(),
-            request.get_header().get_inputs()[0],
-            request.get_header().get_outputs()[0]
+            payload.get_name_c()
         );
 
         #[cfg(target_arch = "wasm32")]
@@ -641,7 +639,10 @@ fn apply(
     let handler = IntkeyMultiplyTransactionHandler::new();
     match handler.apply(request, context) {
         Ok(_) => Ok(true),
-        Err(err) => Err(err),
+        Err(err) => {
+            info!("{}", err);
+            Err(err)
+        }
     }
 }
 

--- a/sdk/src/externs.rs
+++ b/sdk/src/externs.rs
@@ -36,4 +36,6 @@ extern "C" {
         public_key: WasmPtr,
         payload: WasmPtr,
     ) -> i32;
+    pub fn log_buffer(log_level: WasmPtr, log_string: WasmPtr);
+    pub fn log_level() -> WasmPtr;
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -685,3 +685,49 @@ unsafe fn ptr_to_vec(ptr: WasmPtr) -> Result<Option<Vec<u8>>, WasmSdkError> {
     }
     Ok(Some(vec))
 }
+
+#[derive(PartialOrd, PartialEq, Copy, Clone)]
+pub enum LogLevel{
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error
+}
+
+pub fn log_message(log_level: LogLevel, log_string: String) {
+    unsafe {
+        // WasmBuffer was created properly, log message otherwise ignore
+        if let Ok(log_buffer) =  WasmBuffer::new(log_string.as_bytes()) {
+            match log_level {
+                LogLevel::Trace => externs::log_buffer(4 as i32, log_buffer.into_raw()),
+                LogLevel::Debug => externs::log_buffer(3 as i32, log_buffer.into_raw()),
+                LogLevel::Info => externs::log_buffer(2 as i32, log_buffer.into_raw()),
+                LogLevel::Warn => externs::log_buffer(1 as i32, log_buffer.into_raw()),
+                LogLevel::Error => externs::log_buffer(0 as i32, log_buffer.into_raw()),
+            };
+        }
+    }
+}
+
+
+pub fn log_level() -> LogLevel {
+    unsafe {
+        match externs::log_level() {
+            4 => LogLevel::Trace,
+            3 => LogLevel::Debug,
+            2 => LogLevel::Info,
+            1 => LogLevel::Warn,
+            _ => LogLevel::Error,
+        }
+    }
+
+}
+
+pub fn log_enabled(lvl: LogLevel) -> bool {
+    if lvl >= log_level() {
+        true
+    } else {
+        false
+    }
+}

--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -12,35 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! The following are no-op log macros that will be used when running a smart contract in
-//! Sabre.
+//! The following are logging macros that will be used when running a smart contract in
+//! Sabre. The log level is the same level set on the sabre transaction processor running the
+//! smart contract.
 
 #[macro_export]
 macro_rules! log {
-    ($lvl:expr, $($arg:tt)+) => {};
+    ($lvl:path, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if ::sabre_sdk::log_enabled(lvl) {
+            let x = format_args!($($arg)*).to_string();
+            ::sabre_sdk::log_message(lvl, x);
+        }
+    })
 }
 
 #[macro_export]
 macro_rules! trace {
-    ($($arg:tt)*) => {};
+    ($($arg:tt)*) =>(log!(::sabre_sdk::LogLevel::Trace, $($arg)*))
 }
 
 #[macro_export]
 macro_rules! debug {
-    ($($arg:tt)*) => {};
+    ($($arg:tt)*) =>(log!(::sabre_sdk::LogLevel::Debug, $($arg)*))
 }
 
 #[macro_export]
 macro_rules! info {
-    ($($arg:tt)*) => {};
+    ($($arg:tt)*) =>(log!(::sabre_sdk::LogLevel::Info, $($arg)*))
 }
 
 #[macro_export]
 macro_rules! warn {
-    ($($arg:tt)*) => {};
+    ($($arg:tt)*) =>(log!(::sabre_sdk::LogLevel::Warn, $($arg)*))
 }
-
 #[macro_export]
 macro_rules! error {
-    ($($arg:tt)*) => {};
+    ($($arg:tt)*) =>(log!(::sabre_sdk::LogLevel::Error, $($arg)*))
 }

--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -35,8 +35,8 @@ path = "src/main.rs"
 [dependencies]
 sawtooth-sdk = "0.3"
 sabre-sdk = {path = "../sdk"}
-log = "0.3.8"
-simple_logger = "0.4.0"
+log = "0.4"
+simple_logger = "1"
 clap = "2"
 protobuf = "2"
 rust-crypto = "0.2.36"

--- a/tp/src/main.rs
+++ b/tp/src/main.rs
@@ -15,7 +15,7 @@
 #[macro_use]
 extern crate clap;
 
-use log::LogLevel;
+use log::Level;
 
 use sawtooth_sabre::handler::SabreTransactionHandler;
 use sawtooth_sdk::processor::TransactionProcessor;
@@ -31,9 +31,10 @@ fn main() {
     .get_matches();
 
     let logger = match matches.occurrences_of("verbose") {
-        1 => simple_logger::init_with_level(LogLevel::Info),
-        2 => simple_logger::init_with_level(LogLevel::Debug),
-        0 | _ => simple_logger::init_with_level(LogLevel::Warn),
+        0 => simple_logger::init_with_level(Level::Warn),
+        1 => simple_logger::init_with_level(Level::Info),
+        2 => simple_logger::init_with_level(Level::Debug),
+        3 | _ => simple_logger::init_with_level(Level::Trace),
     };
 
     logger.expect("Failed to create logger");


### PR DESCRIPTION
The sabre sdk now has logging macros, where if the log level
is currently supported will format the log string, write the
string to memory and call the extern function to log the message
in the Sabre transaction processor.

The log level set on the Sabre TP will also be enforced on the
smart contracts.