### PR TITLE
Update CliError to use source instead of description and cause

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -44,27 +44,15 @@ pub enum CliError {
 }
 
 impl StdError for CliError {
-    fn description(&self) -> &str {
-        match *self {
-            CliError::UserError(ref s) => &s,
-            CliError::IoError(ref err) => err.description(),
-            CliError::SigningError(ref err) => err.description(),
-            CliError::ProtobufError(ref err) => err.description(),
-            CliError::HyperError(ref err) => err.description(),
-            CliError::ProtocolBuildError(ref err) => err.description(),
-            CliError::ProtoConversionError(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
-        match *self {
-            CliError::UserError(ref _s) => None,
-            CliError::IoError(ref err) => Some(err.borrow()),
-            CliError::SigningError(ref err) => Some(err.borrow()),
-            CliError::ProtobufError(ref err) => Some(err.borrow()),
-            CliError::HyperError(ref err) => Some(err.borrow()),
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            CliError::UserError(_) => None,
+            CliError::IoError(err) => Some(err),
+            CliError::SigningError(err) => Some(err),
+            CliError::ProtobufError(err) => Some(err),
+            CliError::HyperError(err) => Some(err),
             CliError::ProtocolBuildError(ref err) => Some(err.borrow()),
-            CliError::ProtoConversionError(ref err) => Some(err.borrow()),
+            CliError::ProtoConversionError(err) => Some(err),
         }
     }
 }

--- a/integration/tests/test_sabre.rs
+++ b/integration/tests/test_sabre.rs
@@ -57,12 +57,6 @@ impl StdError for TestError {
             TestError::TestError(ref s) => &s,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            TestError::TestError(ref _s) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for TestError {

--- a/sdk/src/protocol/payload.rs
+++ b/sdk/src/protocol/payload.rs
@@ -172,12 +172,6 @@ impl StdError for CreateContractActionBuildError {
             CreateContractActionBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            CreateContractActionBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for CreateContractActionBuildError {
@@ -337,12 +331,6 @@ impl StdError for DeleteContractActionBuildError {
             DeleteContractActionBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            DeleteContractActionBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for DeleteContractActionBuildError {
@@ -488,12 +476,6 @@ impl StdError for ExecuteContractActionBuildError {
     fn description(&self) -> &str {
         match *self {
             ExecuteContractActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            ExecuteContractActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -659,12 +641,6 @@ impl StdError for CreateContractRegistryActionBuildError {
             CreateContractRegistryActionBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            CreateContractRegistryActionBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for CreateContractRegistryActionBuildError {
@@ -790,12 +766,6 @@ impl StdError for DeleteContractRegistryActionBuildError {
     fn description(&self) -> &str {
         match *self {
             DeleteContractRegistryActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            DeleteContractRegistryActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -928,12 +898,6 @@ impl StdError for UpdateContractRegistryOwnersActionBuildError {
     fn description(&self) -> &str {
         match *self {
             UpdateContractRegistryOwnersActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            UpdateContractRegistryOwnersActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -1073,12 +1037,6 @@ impl StdError for CreateNamespaceRegistryActionBuildError {
             CreateNamespaceRegistryActionBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            CreateNamespaceRegistryActionBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for CreateNamespaceRegistryActionBuildError {
@@ -1203,12 +1161,6 @@ impl StdError for DeleteNamespaceRegistryActionBuildError {
     fn description(&self) -> &str {
         match *self {
             DeleteNamespaceRegistryActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            DeleteNamespaceRegistryActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -1341,12 +1293,6 @@ impl StdError for UpdateNamespaceRegistryOwnersActionBuildError {
     fn description(&self) -> &str {
         match *self {
             UpdateNamespaceRegistryOwnersActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            UpdateNamespaceRegistryOwnersActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -1520,12 +1466,6 @@ impl StdError for CreateNamespaceRegistryPermissionActionBuildError {
     fn description(&self) -> &str {
         match *self {
             CreateNamespaceRegistryPermissionActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            CreateNamespaceRegistryPermissionActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -1705,12 +1645,6 @@ impl StdError for DeleteNamespaceRegistryPermissionActionBuildError {
             DeleteNamespaceRegistryPermissionActionBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            DeleteNamespaceRegistryPermissionActionBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for DeleteNamespaceRegistryPermissionActionBuildError {
@@ -1858,12 +1792,6 @@ impl StdError for CreateSmartPermissionActionBuildError {
     fn description(&self) -> &str {
         match *self {
             CreateSmartPermissionActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            CreateSmartPermissionActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -2023,12 +1951,6 @@ impl StdError for UpdateSmartPermissionActionBuildError {
             UpdateSmartPermissionActionBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            UpdateSmartPermissionActionBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for UpdateSmartPermissionActionBuildError {
@@ -2177,12 +2099,6 @@ impl StdError for DeleteSmartPermissionActionBuildError {
     fn description(&self) -> &str {
         match *self {
             DeleteSmartPermissionActionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            DeleteSmartPermissionActionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -2448,12 +2364,6 @@ impl StdError for SabrePayloadBuildError {
     fn description(&self) -> &str {
         match *self {
             SabrePayloadBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            SabrePayloadBuildError::MissingField(_) => None,
         }
     }
 }

--- a/sdk/src/protocol/pike/state.rs
+++ b/sdk/src/protocol/pike/state.rs
@@ -99,12 +99,6 @@ impl StdError for KeyValueEntryBuildError {
             KeyValueEntryBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            KeyValueEntryBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for KeyValueEntryBuildError {
@@ -253,12 +247,6 @@ impl StdError for AgentBuildError {
     fn description(&self) -> &str {
         match *self {
             AgentBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            AgentBuildError::MissingField(_) => None,
         }
     }
 }
@@ -414,12 +402,6 @@ impl StdError for AgentListBuildError {
             AgentListBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            AgentListBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for AgentListBuildError {
@@ -560,12 +542,6 @@ impl StdError for OrganizationBuildError {
     fn description(&self) -> &str {
         match *self {
             OrganizationBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            OrganizationBuildError::MissingField(_) => None,
         }
     }
 }
@@ -716,12 +692,6 @@ impl StdError for OrganizationListBuildError {
     fn description(&self) -> &str {
         match *self {
             OrganizationListBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            OrganizationListBuildError::MissingField(_) => None,
         }
     }
 }

--- a/sdk/src/protocol/state.rs
+++ b/sdk/src/protocol/state.rs
@@ -89,12 +89,6 @@ impl StdError for VersionBuildError {
             VersionBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            VersionBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for VersionBuildError {
@@ -259,12 +253,6 @@ impl StdError for ContractRegistryBuildError {
             ContractRegistryBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            ContractRegistryBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for ContractRegistryBuildError {
@@ -416,12 +404,6 @@ impl StdError for ContractRegistryListBuildError {
             ContractRegistryListBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            ContractRegistryListBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for ContractRegistryListBuildError {
@@ -523,12 +505,6 @@ impl StdError for PermissionBuildError {
     fn description(&self) -> &str {
         match *self {
             PermissionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            PermissionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -691,12 +667,6 @@ impl StdError for NamespaceRegistryBuildError {
             NamespaceRegistryBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            NamespaceRegistryBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for NamespaceRegistryBuildError {
@@ -848,12 +818,6 @@ impl StdError for NamespaceRegistryListBuildError {
             NamespaceRegistryListBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            NamespaceRegistryListBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for NamespaceRegistryListBuildError {
@@ -1003,12 +967,6 @@ impl StdError for ContractBuildError {
     fn description(&self) -> &str {
         match *self {
             ContractBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            ContractBuildError::MissingField(_) => None,
         }
     }
 }
@@ -1200,12 +1158,6 @@ impl StdError for ContractListBuildError {
             ContractListBuildError::MissingField(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            ContractListBuildError::MissingField(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for ContractListBuildError {
@@ -1328,12 +1280,6 @@ impl StdError for SmartPermissionBuildError {
     fn description(&self) -> &str {
         match *self {
             SmartPermissionBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            SmartPermissionBuildError::MissingField(_) => None,
         }
     }
 }
@@ -1482,12 +1428,6 @@ impl StdError for SmartPermissionListBuildError {
     fn description(&self) -> &str {
         match *self {
             SmartPermissionListBuildError::MissingField(ref msg) => msg,
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            SmartPermissionListBuildError::MissingField(_) => None,
         }
     }
 }

--- a/sdk/src/protos.rs
+++ b/sdk/src/protos.rs
@@ -27,13 +27,6 @@ impl StdError for ProtoConversionError {
             ProtoConversionError::InvalidTypeError(ref msg) => msg,
         }
     }
-
-    fn cause(&self) -> Option<&StdError> {
-        match *self {
-            ProtoConversionError::SerializationError(_) => None,
-            ProtoConversionError::InvalidTypeError(_) => None,
-        }
-    }
 }
 
 impl std::fmt::Display for ProtoConversionError {


### PR DESCRIPTION
This removes the deprecated use of description and cause.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>