### PR TITLE
Propose new maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @dcmiddle @jsmitchell @peterschwarz @rbuysse @ryanlassigbanks @vaporos
+*       @agunde406 @dcmiddle @jsmitchell @peterschwarz  @rberg2 @rbuysse @ryanlassigbanks @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@
 | Dan Middleton | dcmiddle | Dan |
 | James Mitchell | jsmitchell | jsmitchell |
 | Peter Schwarz | peterschwarz | pschwarz |
+| Richard Berg | rberg2 | rberg2 |
 | Ryan Banks | RyanLassigBanks | RobinBanks |
 | Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |


### PR DESCRIPTION
Add Richard Berg to maintainers.

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.