### PR TITLE
Fix versioning of packaged Rust components

### DIFF
--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -48,8 +48,9 @@ COPY . /project
 
 WORKDIR /project/cli
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== sabre cli docker build ===-------------
 

--- a/cli/Dockerfile-installed-xenial
+++ b/cli/Dockerfile-installed-xenial
@@ -45,8 +45,9 @@ COPY . /project
 
 WORKDIR /project/cli
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== sabre cli docker build ===-------------
 

--- a/contracts/sawtooth-pike/api/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/api/Dockerfile-installed-bionic
@@ -46,8 +46,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/api
 
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/" Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${VERSION}\"/" Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== pike api docker build ===-------------
 

--- a/contracts/sawtooth-pike/api/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/api/Dockerfile-installed-xenial
@@ -46,8 +46,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/api
 
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/" Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${VERSION}\"/" Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== pike api docker build ===-------------
 

--- a/contracts/sawtooth-pike/cli/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/cli/Dockerfile-installed-bionic
@@ -44,8 +44,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/cli
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== pike cli docker build ===-------------
 

--- a/contracts/sawtooth-pike/cli/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/cli/Dockerfile-installed-xenial
@@ -44,8 +44,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/cli
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== pike cli docker build ===-------------
 

--- a/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-bionic
@@ -45,8 +45,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/state_delta_export
 
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/" Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${VERSION}\"/" Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== state delta export docker build ===-------------
 

--- a/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-xenial
@@ -45,8 +45,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/state_delta_export
 
-RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/" Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${VERSION}\"/" Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== state delta export docker build ===-------------
 

--- a/contracts/sawtooth-pike/tp/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/tp/Dockerfile-installed-bionic
@@ -44,8 +44,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/tp
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== pike tp docker build ===-------------
 

--- a/contracts/sawtooth-pike/tp/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/tp/Dockerfile-installed-xenial
@@ -44,8 +44,9 @@ COPY . /project
 
 WORKDIR /project/contracts/sawtooth-pike/tp
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== pike tp docker build ===-------------
 

--- a/tp/Dockerfile-installed-bionic
+++ b/tp/Dockerfile-installed-bionic
@@ -48,8 +48,9 @@ COPY . /project
 
 WORKDIR /project/tp
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== sabre tp build ===-------------
 

--- a/tp/Dockerfile-installed-xenial
+++ b/tp/Dockerfile-installed-xenial
@@ -45,8 +45,9 @@ COPY . /project
 
 WORKDIR /project/tp
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== sabre tp build ===-------------
 


### PR DESCRIPTION
The behavior of cargo-deb was changed to generate version numbers with
tildes instead of dashes. This is causing newly built packages to sort
below older releases.

https://github.com/mmstick/cargo-deb/pull/102

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>