### PR TITLE
Expose the address of the admins setting

### DIFF
--- a/cli/src/transaction.rs
+++ b/cli/src/transaction.rs
@@ -18,11 +18,11 @@
 use std::time::Instant;
 
 use crypto::digest::Digest;
-use crypto::sha2::Sha256;
 use crypto::sha2::Sha512;
 use protobuf;
 use protobuf::Message;
 use sabre_sdk::protocol::payload::{Action, SabrePayload};
+use sabre_sdk::protocol::ADMINISTRATORS_SETTING_ADDRESS;
 use sabre_sdk::protos::IntoBytes;
 use sawtooth_sdk::messages::batch::Batch;
 use sawtooth_sdk::messages::batch::BatchHeader;
@@ -54,8 +54,6 @@ const SMART_PERMISSION_PREFIX: &str = "00ec03";
 const PIKE_AGENT_PREFIX: &str = "cad11d00";
 
 const PIKE_ORG_PREFIX: &str = "cad11d01";
-
-const SETTING_PREFIX: &str = "000000";
 
 /// Creates a nonce appropriate for a TransactionHeader
 fn create_nonce() -> String {
@@ -133,15 +131,6 @@ fn compute_contract_address(name: &str, version: &str) -> String {
     String::from(CONTRACT_PREFIX) + &bytes_to_hex_str(hash)[..64]
 }
 
-/// Returns a state address for a the setting sawtooth.swa.administrators
-fn compute_setting_admin_address() -> String {
-    SETTING_PREFIX.to_string()
-        + &hash_256("sawtooth", 16)
-        + &hash_256("swa", 16)
-        + &hash_256("administrators", 16)
-        + &hash_256("", 16)
-}
-
 /// Returns a state address for a given agent name
 ///
 /// # Arguments
@@ -188,23 +177,6 @@ fn compute_smart_permission_address(org_id: &str, name: &str) -> String {
     String::from(SMART_PERMISSION_PREFIX)
         + &sha_org_id.result_str()[..6].to_string()
         + &sha_name.result_str()[..58].to_string()
-}
-
-/// Returns a Sha256 hash of the given length
-///
-/// # Arguments
-///
-/// * `to_hash` - string to hash
-/// * `num` - the length of the string returned
-fn hash_256(to_hash: &str, num: usize) -> String {
-    let mut sha = Sha256::new();
-    sha.input_str(to_hash);
-    let temp = sha.result_str().to_string();
-    let hash = match temp.get(..num) {
-        Some(x) => x,
-        None => "",
-    };
-    hash.to_string()
 }
 
 /// Returns a Transaction for the given Payload and Signer
@@ -308,7 +280,7 @@ pub fn create_transaction(
             let name = create_contract_registry.name();
             let addresses = vec![
                 compute_contract_registry_address(name),
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }
@@ -316,7 +288,7 @@ pub fn create_transaction(
             let name = delete_contract_registry.name();
             let addresses = vec![
                 compute_contract_registry_address(name),
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }
@@ -324,7 +296,7 @@ pub fn create_transaction(
             let name = update_contract_registry_owners.name();
             let addresses = vec![
                 compute_contract_registry_address(name),
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }
@@ -332,7 +304,7 @@ pub fn create_transaction(
             let namespace = create_namespace_registry.namespace();
             let addresses = vec![
                 compute_namespace_registry_address(namespace)?,
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }
@@ -340,7 +312,7 @@ pub fn create_transaction(
             let namespace = delete_namespace_registry.namespace();
             let addresses = vec![
                 compute_namespace_registry_address(namespace)?,
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }
@@ -348,7 +320,7 @@ pub fn create_transaction(
             let namespace = update_namespace_registry_owners.namespace();
             let addresses = vec![
                 compute_namespace_registry_address(namespace)?,
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }
@@ -356,7 +328,7 @@ pub fn create_transaction(
             let namespace = create_namespace_registry_permission.namespace();
             let addresses = vec![
                 compute_namespace_registry_address(namespace)?,
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }
@@ -364,7 +336,7 @@ pub fn create_transaction(
             let namespace = delete_namespace_registry_permission.namespace();
             let addresses = vec![
                 compute_namespace_registry_address(namespace)?,
-                compute_setting_admin_address(),
+                ADMINISTRATORS_SETTING_ADDRESS.into(),
             ];
             (addresses.clone(), addresses)
         }

--- a/sdk/src/protocol/mod.rs
+++ b/sdk/src/protocol/mod.rs
@@ -15,3 +15,7 @@
 pub mod payload;
 pub mod pike;
 pub mod state;
+
+pub const ADMINISTRATORS_SETTING_ADDRESS: &str =
+    "000000a87cb5eafdcca6a814e4add97c4b517d3c530c2f44b31d18e3b0c44298fc1c14";
+pub const ADMINISTRATORS_SETTING_KEY: &str = "sawtooth.swa.administrators";

--- a/tp/src/addressing.rs
+++ b/tp/src/addressing.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crypto::digest::Digest;
-use crypto::sha2::Sha256;
 use crypto::sha2::Sha512;
 use sawtooth_sdk::processor::handler::ApplyError;
 
@@ -32,8 +31,6 @@ const SMART_PERMISSION_PREFIX: &str = "00ec03";
 const PIKE_AGENT_PREFIX: &str = "cad11d00";
 
 const PIKE_ORG_PREFIX: &str = "cad11d01";
-
-const SETTING_PREFIX: &str = "000000";
 
 pub fn hash(to_hash: &str, num: usize) -> Result<String, ApplyError> {
     let mut sha = Sha512::new();
@@ -63,22 +60,6 @@ fn bytes_to_hex_str(b: &[u8]) -> String {
         .join("")
 }
 
-pub fn hash_256(to_hash: &str, num: usize) -> Result<String, ApplyError> {
-    let mut sha = Sha256::new();
-    sha.input_str(to_hash);
-    let temp = sha.result_str().to_string();
-    let hash = match temp.get(..num) {
-        Some(x) => x,
-        None => {
-            return Err(ApplyError::InvalidTransaction(format!(
-                "Cannot hash {} to Sha256 and return String with len {}",
-                to_hash, num
-            )));
-        }
-    };
-    Ok(hash.into())
-}
-
 pub fn make_contract_address(name: &str, version: &str) -> Result<String, ApplyError> {
     Ok(CONTRACT_PREFIX.to_string() + &hash(&(name.to_string() + "," + version), 64)?)
 }
@@ -98,14 +79,6 @@ pub fn make_namespace_registry_address(namespace: &str) -> Result<String, ApplyE
         }
     };
     Ok(NAMESPACE_REGISTRY_PREFIX.to_string() + &hash(prefix, 64)?)
-}
-
-pub fn get_sawtooth_admins_address() -> Result<String, ApplyError> {
-    Ok(SETTING_PREFIX.to_string()
-        + &hash_256("sawtooth", 16)?
-        + &hash_256("swa", 16)?
-        + &hash_256("administrators", 16)?
-        + &hash_256("", 16)?)
 }
 
 /// Returns a state address for a smart permission

--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -36,6 +36,7 @@ use sabre_sdk::protocol::payload::{
     UpdateContractRegistryOwnersAction, UpdateNamespaceRegistryOwnersAction,
     UpdateSmartPermissionAction,
 };
+use sabre_sdk::protocol::ADMINISTRATORS_SETTING_KEY;
 
 /// The namespace registry prefix for global state (00ec00)
 const NAMESPACE_REGISTRY_PREFIX: &str = "00ec00";
@@ -542,7 +543,7 @@ fn create_contract_registry(
     };
 
     for entry in setting.get_entries() {
-        if entry.key == "sawtooth.swa.administrators" {
+        if entry.key == ADMINISTRATORS_SETTING_KEY {
             let values = entry.value.split(',');
             let value_vec: Vec<&str> = values.collect();
             if !value_vec.contains(&signer) {
@@ -683,7 +684,7 @@ fn create_namespace_registry(
     };
 
     for entry in setting.get_entries() {
-        if entry.key == "sawtooth.swa.administrators" {
+        if entry.key == ADMINISTRATORS_SETTING_KEY {
             let values = entry.value.split(',');
             let value_vec: Vec<&str> = values.collect();
             if !value_vec.contains(&signer) {
@@ -1080,7 +1081,7 @@ fn can_update_namespace_registry(
         };
 
         for entry in setting.get_entries() {
-            if entry.key == "sawtooth.swa.administrators" {
+            if entry.key == ADMINISTRATORS_SETTING_KEY {
                 let values = entry.value.split(',');
                 let value_vec: Vec<&str> = values.collect();
                 if !value_vec.contains(&signer) {
@@ -1119,7 +1120,7 @@ fn can_update_contract_registry(
         };
 
         for entry in setting.get_entries() {
-            if entry.key == "sawtooth.swa.administrators" {
+            if entry.key == ADMINISTRATORS_SETTING_KEY {
                 let values = entry.value.split(',');
                 let value_vec: Vec<&str> = values.collect();
                 if !value_vec.contains(&signer) {

--- a/tp/src/lib.rs
+++ b/tp/src/lib.rs
@@ -20,3 +20,5 @@ pub mod handler;
 mod payload;
 mod state;
 mod wasm_executor;
+
+pub use sabre_sdk::protocol::{ADMINISTRATORS_SETTING_ADDRESS, ADMINISTRATORS_SETTING_KEY};

--- a/tp/src/state.rs
+++ b/tp/src/state.rs
@@ -17,6 +17,7 @@ use sabre_sdk::protocol::state::{
     ContractRegistryListBuilder, NamespaceRegistry, NamespaceRegistryList,
     NamespaceRegistryListBuilder, SmartPermission, SmartPermissionList, SmartPermissionListBuilder,
 };
+use sabre_sdk::protocol::ADMINISTRATORS_SETTING_ADDRESS;
 use sabre_sdk::protos::{FromBytes, IntoBytes};
 use sawtooth_sdk::messages::setting::Setting;
 use sawtooth_sdk::processor::handler::ApplyError;
@@ -24,8 +25,7 @@ use sawtooth_sdk::processor::handler::TransactionContext;
 
 use crate::addressing::{
     compute_agent_address, compute_org_address, compute_smart_permission_address,
-    get_sawtooth_admins_address, make_contract_address, make_contract_registry_address,
-    make_namespace_registry_address,
+    make_contract_address, make_contract_registry_address, make_namespace_registry_address,
 };
 
 pub struct SabreState<'a> {
@@ -42,8 +42,9 @@ impl<'a> SabreState<'a> {
     }
 
     pub fn get_admin_setting(&mut self) -> Result<Option<Setting>, ApplyError> {
-        let address = get_sawtooth_admins_address()?;
-        let d = self.context.get_state_entry(&address)?;
+        let d = self
+            .context
+            .get_state_entry(ADMINISTRATORS_SETTING_ADDRESS)?;
         match d {
             Some(packed) => {
                 let setting: Setting =


### PR DESCRIPTION
Exposes the address of the admins setting in the SDK; this is necessary
because applications that use Sabre will need to ensure that the setting
is properly set when Sabre is started.

Signed-off-by: Logan Seeley <seeley@bitwise.io>