### PR TITLE
Simplified Transaction Context

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -31,3 +31,10 @@ protobuf = "2"
 [build-dependencies]
 protoc-rust = "2"
 glob = "0.2"
+
+[features]
+default = []
+
+experimental = ["simple-state"]
+
+simple-state = []

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -27,6 +27,7 @@ edition = "2018"
 
 [dependencies]
 protobuf = "2"
+rust-crypto-wasm = "0.3"
 
 [build-dependencies]
 protoc-rust = "2"

--- a/sdk/protos/simple_state.proto
+++ b/sdk/protos/simple_state.proto
@@ -1,0 +1,48 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message StateEntryValue {
+  enum ValueType {
+    TYPE_UNSET = 0;
+    INT64 = 1;
+    INT32 = 2;
+    UINT64 = 3;
+    UINT32 = 4;
+    STRING = 5;
+    BYTES = 6;
+  }
+  string key = 1;
+
+  ValueType value_type = 2;
+
+  int32 int32_value = 3;
+  int64 int64_value = 4;
+  uint32 uint32_value = 5;
+  uint64 uint64_value = 6;
+  string string_value = 7;
+  bytes bytes_value = 8;
+}
+
+
+message StateEntry {
+  string normalized_key = 1;
+  repeated StateEntryValue state_entry_values = 2;
+}
+
+message StateEntryList {
+  repeated StateEntry entries = 1;
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -626,7 +626,7 @@ pub enum WasmSdkError {
 impl std::fmt::Display for WasmSdkError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            WasmSdkError::InvalidTransaction(ref s) => write!(f, "InvalidTransactio: {}", s),
+            WasmSdkError::InvalidTransaction(ref s) => write!(f, "InvalidTransaction: {}", s),
             WasmSdkError::InternalError(ref s) => write!(f, "InternalError: {}", s),
             WasmSdkError::StateSetError(ref s) => write!(f, "StateSetError: {}", s),
             WasmSdkError::AllocError(ref s) => write!(f, "AllocError: {}", s),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -18,6 +18,8 @@ mod externs;
 pub mod log;
 pub mod protocol;
 pub mod protos;
+#[cfg(feature = "simple-state")]
+pub mod simple_state;
 
 use std::collections::HashMap;
 use std::error::Error;

--- a/sdk/src/protocol/mod.rs
+++ b/sdk/src/protocol/mod.rs
@@ -14,6 +14,8 @@
 
 pub mod payload;
 pub mod pike;
+#[cfg(feature = "simple-state")]
+pub mod simple_state;
 pub mod state;
 
 pub const ADMINISTRATORS_SETTING_ADDRESS: &str =

--- a/sdk/src/protocol/simple_state.rs
+++ b/sdk/src/protocol/simple_state.rs
@@ -1,0 +1,483 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf::Message;
+use protobuf::RepeatedField;
+
+use std::error::Error as StdError;
+
+use crate::protos;
+use crate::protos::{
+    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+
+/// Native implementation for ValueType
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueType {
+    Int64(i64),
+    Int32(i32),
+    UInt64(u64),
+    UInt32(u32),
+    String(String),
+    Bytes(Vec<u8>),
+}
+
+impl std::fmt::Display for ValueType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ValueType::Int64(_) => write!(f, "State Value Type: i64"),
+            ValueType::Int32(_) => write!(f, "State Value Type: i32"),
+            ValueType::UInt64(_) => write!(f, "State Value Type: u64"),
+            ValueType::UInt32(_) => write!(f, "State Value Type: u32"),
+            ValueType::String(_) => write!(f, "State Value Type: String"),
+            ValueType::Bytes(_) => write!(f, "State Value Type: Vec<u8>"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateEntryValue {
+    key: String,
+    value: ValueType,
+}
+
+impl StateEntryValue {
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &ValueType {
+        &self.value
+    }
+}
+
+impl FromProto<protos::simple_state::StateEntryValue> for StateEntryValue {
+    fn from_proto(
+        proto: protos::simple_state::StateEntryValue,
+    ) -> Result<Self, ProtoConversionError> {
+        let value = match proto.get_value_type() {
+            protos::simple_state::StateEntryValue_ValueType::INT64 => {
+                ValueType::Int64(proto.get_int64_value())
+            }
+            protos::simple_state::StateEntryValue_ValueType::INT32 => {
+                ValueType::Int32(proto.get_int32_value())
+            }
+            protos::simple_state::StateEntryValue_ValueType::UINT64 => {
+                ValueType::UInt64(proto.get_uint64_value())
+            }
+            protos::simple_state::StateEntryValue_ValueType::UINT32 => {
+                ValueType::UInt32(proto.get_uint32_value())
+            }
+            protos::simple_state::StateEntryValue_ValueType::STRING => {
+                ValueType::String(proto.get_string_value().to_string())
+            }
+            protos::simple_state::StateEntryValue_ValueType::BYTES => {
+                ValueType::Bytes(proto.get_bytes_value().to_vec())
+            }
+            protos::simple_state::StateEntryValue_ValueType::TYPE_UNSET => {
+                return Err(ProtoConversionError::InvalidTypeError(
+                    "Cannot convert StateEntryValue_ValueType with type unset.".to_string(),
+                ));
+            }
+        };
+
+        Ok(StateEntryValue {
+            key: proto.get_key().to_string(),
+            value,
+        })
+    }
+}
+
+impl FromNative<StateEntryValue> for protos::simple_state::StateEntryValue {
+    fn from_native(native: StateEntryValue) -> Result<Self, ProtoConversionError> {
+        let mut proto = protos::simple_state::StateEntryValue::new();
+        proto.set_key(native.key().to_string());
+        match native.value() {
+            ValueType::Int64(value) => {
+                proto.set_value_type(protos::simple_state::StateEntryValue_ValueType::INT64);
+                proto.set_int64_value(value.clone());
+            }
+            ValueType::Int32(value) => {
+                proto.set_value_type(protos::simple_state::StateEntryValue_ValueType::INT32);
+                proto.set_int32_value(value.clone());
+            }
+            ValueType::UInt64(value) => {
+                proto.set_value_type(protos::simple_state::StateEntryValue_ValueType::UINT64);
+                proto.set_uint64_value(value.clone());
+            }
+            ValueType::UInt32(value) => {
+                proto.set_value_type(protos::simple_state::StateEntryValue_ValueType::UINT32);
+                proto.set_uint32_value(value.clone());
+            }
+            ValueType::String(value) => {
+                proto.set_value_type(protos::simple_state::StateEntryValue_ValueType::STRING);
+                proto.set_string_value(value.clone());
+            }
+            ValueType::Bytes(value) => {
+                proto.set_value_type(protos::simple_state::StateEntryValue_ValueType::BYTES);
+                proto.set_bytes_value(value.clone());
+            }
+        }
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<StateEntryValue> for StateEntryValue {
+    fn from_bytes(bytes: &[u8]) -> Result<StateEntryValue, ProtoConversionError> {
+        let proto: protos::simple_state::StateEntryValue = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get StateEntryValue from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for StateEntryValue {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from StateEntryValue".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::simple_state::StateEntryValue> for StateEntryValue {}
+impl IntoNative<StateEntryValue> for protos::simple_state::StateEntryValue {}
+
+#[derive(Debug)]
+pub enum StateEntryValueBuildError {
+    MissingField(String),
+}
+
+impl StdError for StateEntryValueBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            StateEntryValueBuildError::MissingField(ref msg) => msg,
+        }
+    }
+}
+
+impl std::fmt::Display for StateEntryValueBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            StateEntryValueBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create StateEntryValue
+#[derive(Default, Clone)]
+pub struct StateEntryValueBuilder {
+    key: Option<String>,
+    value: Option<ValueType>,
+}
+
+impl StateEntryValueBuilder {
+    pub fn new() -> Self {
+        StateEntryValueBuilder::default()
+    }
+
+    pub fn with_key(mut self, key: String) -> StateEntryValueBuilder {
+        self.key = Some(key);
+        self
+    }
+
+    pub fn with_value(mut self, value: ValueType) -> StateEntryValueBuilder {
+        self.value = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<StateEntryValue, StateEntryValueBuildError> {
+        let key = self.key.ok_or_else(|| {
+            StateEntryValueBuildError::MissingField("'key' field is required".to_string())
+        })?;
+
+        let value = self.value.ok_or_else(|| {
+            StateEntryValueBuildError::MissingField("'value' field is required".to_string())
+        })?;
+
+        Ok(StateEntryValue { key, value })
+    }
+}
+
+/// Native implementation for StateEntry
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct StateEntry {
+    normalized_key: String,
+    state_entry_values: Vec<StateEntryValue>,
+}
+
+impl StateEntry {
+    pub fn normalized_key(&self) -> &str {
+        &self.normalized_key
+    }
+
+    pub fn state_entry_values(&self) -> &[StateEntryValue] {
+        &self.state_entry_values
+    }
+}
+
+impl FromProto<protos::simple_state::StateEntry> for StateEntry {
+    fn from_proto(proto: protos::simple_state::StateEntry) -> Result<Self, ProtoConversionError> {
+        Ok(StateEntry {
+            normalized_key: proto.get_normalized_key().to_string(),
+            state_entry_values: proto
+                .get_state_entry_values()
+                .to_vec()
+                .into_iter()
+                .map(StateEntryValue::from_proto)
+                .collect::<Result<Vec<StateEntryValue>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<StateEntry> for protos::simple_state::StateEntry {
+    fn from_native(state_entry: StateEntry) -> Result<Self, ProtoConversionError> {
+        let mut proto = protos::simple_state::StateEntry::new();
+        proto.set_normalized_key(state_entry.normalized_key().to_string());
+        proto.set_state_entry_values(RepeatedField::from_vec(
+            state_entry
+                .state_entry_values()
+                .to_vec()
+                .into_iter()
+                .map(StateEntryValue::into_proto)
+                .collect::<Result<
+                    Vec<protos::simple_state::StateEntryValue>,
+                    ProtoConversionError,
+                >>()?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<StateEntry> for StateEntry {
+    fn from_bytes(bytes: &[u8]) -> Result<StateEntry, ProtoConversionError> {
+        let proto: protos::simple_state::StateEntry =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get StateEntry from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for StateEntry {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from StateEntry".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::simple_state::StateEntry> for StateEntry {}
+impl IntoNative<StateEntry> for protos::simple_state::StateEntry {}
+
+#[derive(Debug)]
+pub enum StateEntryBuildError {
+    MissingField(String),
+}
+
+impl StdError for StateEntryBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            StateEntryBuildError::MissingField(ref msg) => msg,
+        }
+    }
+}
+
+impl std::fmt::Display for StateEntryBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            StateEntryBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create StateEntry
+#[derive(Default, Clone)]
+pub struct StateEntryBuilder {
+    normalized_key: Option<String>,
+    state_entry_values: Option<Vec<StateEntryValue>>,
+}
+
+impl StateEntryBuilder {
+    pub fn new() -> Self {
+        StateEntryBuilder::default()
+    }
+
+    pub fn with_normalized_key(mut self, normalized_key: String) -> StateEntryBuilder {
+        self.normalized_key = Some(normalized_key);
+        self
+    }
+
+    pub fn with_state_entry_values(
+        mut self,
+        state_entry_values: Vec<StateEntryValue>,
+    ) -> StateEntryBuilder {
+        self.state_entry_values = Some(state_entry_values);
+        self
+    }
+
+    pub fn build(self) -> Result<StateEntry, StateEntryBuildError> {
+        let normalized_key = self.normalized_key.ok_or_else(|| {
+            StateEntryBuildError::MissingField("'normalized_key' field is required".to_string())
+        })?;
+        let state_entry_values = self.state_entry_values.ok_or_else(|| {
+            StateEntryBuildError::MissingField("'state_entry_values' field is required".to_string())
+        })?;
+
+        Ok(StateEntry {
+            normalized_key,
+            state_entry_values,
+        })
+    }
+}
+
+/// Native implementation for StateEntryList
+#[derive(Default, Debug)]
+pub struct StateEntryList {
+    entries: Vec<StateEntry>,
+}
+
+impl StateEntryList {
+    pub fn entries(&self) -> &[StateEntry] {
+        &self.entries
+    }
+
+    pub fn contains(&self, normalized_key: String) -> bool {
+        let nkeys = self
+            .entries()
+            .to_vec()
+            .into_iter()
+            .map(|e| e.normalized_key().to_string())
+            .collect::<Vec<String>>();
+        nkeys.contains(&normalized_key)
+    }
+}
+
+impl FromProto<protos::simple_state::StateEntryList> for StateEntryList {
+    fn from_proto(
+        proto: protos::simple_state::StateEntryList,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(StateEntryList {
+            entries: proto
+                .get_entries()
+                .to_vec()
+                .into_iter()
+                .map(StateEntry::from_proto)
+                .collect::<Result<Vec<StateEntry>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<StateEntryList> for protos::simple_state::StateEntryList {
+    fn from_native(state_entry_list: StateEntryList) -> Result<Self, ProtoConversionError> {
+        let mut proto = protos::simple_state::StateEntryList::new();
+        proto.set_entries(RepeatedField::from_vec(
+            state_entry_list
+                .entries()
+                .to_vec()
+                .into_iter()
+                .map(StateEntry::into_proto)
+                .collect::<Result<Vec<protos::simple_state::StateEntry>, ProtoConversionError>>()?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<StateEntryList> for StateEntryList {
+    fn from_bytes(bytes: &[u8]) -> Result<StateEntryList, ProtoConversionError> {
+        let proto: protos::simple_state::StateEntryList = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get StateEntryList from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for StateEntryList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from StateEntryList".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::simple_state::StateEntryList> for StateEntryList {}
+impl IntoNative<StateEntryList> for protos::simple_state::StateEntryList {}
+
+#[derive(Debug)]
+pub enum StateEntryListBuildError {
+    MissingField(String),
+}
+
+impl StdError for StateEntryListBuildError {
+    fn description(&self) -> &str {
+        match *self {
+            StateEntryListBuildError::MissingField(ref msg) => msg,
+        }
+    }
+}
+
+impl std::fmt::Display for StateEntryListBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            StateEntryListBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+        }
+    }
+}
+
+/// Builder used to create StateEntryList
+#[derive(Default, Clone)]
+pub struct StateEntryListBuilder {
+    entries: Option<Vec<StateEntry>>,
+}
+
+impl StateEntryListBuilder {
+    pub fn new() -> Self {
+        StateEntryListBuilder::default()
+    }
+
+    pub fn with_state_entries(mut self, entries: Vec<StateEntry>) -> StateEntryListBuilder {
+        self.entries = Some(entries);
+        self
+    }
+
+    pub fn build(self) -> Result<StateEntryList, StateEntryListBuildError> {
+        let entries = self.entries.ok_or_else(|| {
+            StateEntryListBuildError::MissingField("'entries' field is required".to_string())
+        })?;
+
+        Ok(StateEntryList { entries })
+    }
+}

--- a/sdk/src/simple_state/addresser.rs
+++ b/sdk/src/simple_state/addresser.rs
@@ -12,5 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod addresser;
-pub mod error;
+use crate::simple_state::error::SimpleStateError;
+
+pub const ADDRESS_LENGTH: usize = 70;
+
+pub trait Addresser<K> {
+    /// Returns a radix address calculated from the given keys
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - Contains natural keys used to calculate an address
+    ///
+    fn compute(&self, keys: &K) -> Result<String, SimpleStateError>;
+
+    /// Returns a human readable string of the given keys
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - Contains natural keys
+    ///
+    fn normalize(&self, keys: &K) -> String;
+}

--- a/sdk/src/simple_state/addresser.rs
+++ b/sdk/src/simple_state/addresser.rs
@@ -168,6 +168,179 @@ mod tests {
     use super::*;
 
     #[test]
+    // check that the KeyHashAddresser creates a valid radix address with the correct prefix
+    // and valid length
+    fn test_key_hash_addresser() {
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let addr = addresser.compute(&"a".to_string()).unwrap();
+        assert_eq!(addr[..6], "prefix".to_string());
+        assert_eq!(addr.len(), 70);
+
+        let key_hash = hash(64, "a");
+        assert_eq!(addr[6..70], key_hash[..64]);
+
+        let normalized = addresser.normalize(&"b".to_string());
+        assert_eq!(normalized, "b".to_string());
+    }
+
+    #[test]
+    // check that the DoubleKeyHashAddresser creates a valid radix address with the correct prefix
+    // and valid default length, with a key represented as a tuple with two natural keys
+    fn test_double_key_default_length() {
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let key1 = "a";
+        let key1_hash = hash(32, key1);
+        let key2 = "b";
+        let key2_hash = hash(32, key2);
+
+        let addr = addresser
+            .compute(&(key1.to_string(), key2.to_string()))
+            .unwrap();
+        assert_eq!(addr[..6], "prefix".to_string());
+        assert_eq!(addr.len(), 70);
+
+        assert_eq!(addr[6..38], key1_hash[..32]);
+        assert_eq!(addr[38..], key2_hash[..32]);
+
+        let normalized = addresser.normalize(&(key1.to_string(), key2.to_string()));
+        assert_eq!(normalized, "a_b".to_string());
+    }
+
+    #[test]
+    // check that the DoubleKeyHashAddresser creates a valid radix address with the correct prefix
+    // and valid first hash length of 16, with a key represented as a tuple with two natural keys
+    fn test_double_key_custom_length() {
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), Some(16));
+        let key1 = "a";
+        let key1_hash = hash(16, key1);
+        let key2 = "b";
+        let key2_hash = hash(48, key2);
+
+        let addr = addresser
+            .compute(&(key1.to_string(), key2.to_string()))
+            .unwrap();
+        assert_eq!(addr[..6], "prefix".to_string());
+        assert_eq!(addr.len(), 70);
+
+        assert_eq!(addr[6..22], key1_hash[..16]);
+        assert_eq!(addr[22..], key2_hash[..48]);
+
+        let normalized = addresser.normalize(&(key1.to_string(), key2.to_string()));
+        assert_eq!(normalized, "a_b".to_string());
+    }
+
+    #[test]
+    // check that the TripleKeyHashAddresser creates a valid radix address with the correct prefix
+    // and valid default lengths, with a key represented as a tuple with three natural keys
+    fn test_triple_key_default_length() {
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let key1 = "a";
+        let key1_hash = hash(21, key1);
+        let key2 = "b";
+        let key2_hash = hash(21, key2);
+        let key3 = "c";
+        let key3_hash = hash(22, key3);
+
+        let addr = addresser
+            .compute(&(key1.to_string(), key2.to_string(), key3.to_string()))
+            .unwrap();
+        assert_eq!(addr[..6], "prefix".to_string());
+        assert_eq!(addr.len(), 70);
+
+        assert_eq!(addr[6..27], key1_hash[..21]);
+        assert_eq!(addr[27..48], key2_hash[..21]);
+        assert_eq!(addr[48..], key3_hash[..22]);
+
+        let normalized =
+            addresser.normalize(&(key1.to_string(), key2.to_string(), key3.to_string()));
+        assert_eq!(normalized, "a_b_c".to_string());
+    }
+
+    #[test]
+    // check that the TripleKeyHashAddresser creates a valid radix address with the correct prefix
+    // and valid first hash length of 14 and second and third hash length of 25,
+    // with a key represented as a tuple with three natural keys
+    fn test_triple_key_custom_first_length() {
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), Some(14), None);
+        let key1 = "a";
+        let key1_hash = hash(14, key1);
+        let key2 = "b";
+        let key2_hash = hash(25, key2);
+        let key3 = "c";
+        let key3_hash = hash(25, key3);
+
+        let addr = addresser
+            .compute(&(key1.to_string(), key2.to_string(), key3.to_string()))
+            .unwrap();
+        assert_eq!(addr[..6], "prefix".to_string());
+        assert_eq!(addr.len(), 70);
+
+        assert_eq!(addr[6..20], key1_hash[..14]);
+        assert_eq!(addr[20..45], key2_hash[..25]);
+        assert_eq!(addr[45..], key3_hash[..25]);
+
+        let normalized =
+            addresser.normalize(&(key1.to_string(), key2.to_string(), key3.to_string()));
+        assert_eq!(normalized, "a_b_c".to_string());
+    }
+
+    #[test]
+    // check that the TripleKeyHashAddresser creates a valid radix address with the correct prefix
+    // and valid first and last hash length of 25 and second hash length of 14,
+    // with a key represented as a tuple with three natural keys
+    fn test_triple_key_custom_second_length() {
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, Some(14));
+        let key1 = "a";
+        let key1_hash = hash(25, key1);
+        let key2 = "b";
+        let key2_hash = hash(14, key2);
+        let key3 = "c";
+        let key3_hash = hash(25, key3);
+
+        let addr = addresser
+            .compute(&(key1.to_string(), key2.to_string(), key3.to_string()))
+            .unwrap();
+        assert_eq!(addr[..6], "prefix".to_string());
+        assert_eq!(addr.len(), 70);
+
+        assert_eq!(addr[6..31], key1_hash[..25]);
+        assert_eq!(addr[31..45], key2_hash[..14]);
+        assert_eq!(addr[45..], key3_hash[..25]);
+
+        let normalized =
+            addresser.normalize(&(key1.to_string(), key2.to_string(), key3.to_string()));
+        assert_eq!(normalized, "a_b_c".to_string());
+    }
+
+    #[test]
+    // check that the TripleKeyHashAddresser creates a valid radix address with the correct prefix
+    // and valid first and second length of 10 and last hash length of 44,
+    // with a key represented as a tuple with three natural keys
+    fn test_triple_key_custom_lengths() {
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), Some(10), Some(10));
+        let key1 = "a";
+        let key1_hash = hash(10, key1);
+        let key2 = "b";
+        let key2_hash = hash(10, key2);
+        let key3 = "c";
+        let key3_hash = hash(44, key3);
+
+        let addr = addresser
+            .compute(&(key1.to_string(), key2.to_string(), key3.to_string()))
+            .unwrap();
+        assert_eq!(addr[..6], "prefix".to_string());
+        assert_eq!(addr.len(), 70);
+
+        assert_eq!(addr[6..16], key1_hash[..10]);
+        assert_eq!(addr[16..26], key2_hash[..10]);
+        assert_eq!(addr[26..], key3_hash[..44]);
+
+        let normalized =
+            addresser.normalize(&(key1.to_string(), key2.to_string(), key3.to_string()));
+        assert_eq!(normalized, "a_b_c".to_string());
+    }
+
+    #[test]
     // Tests the calculate_hash_lengths function using several different custom first hash lengths
     // and `None` for the second length.
     fn test_calculate_hash_custom_first_length() {

--- a/sdk/src/simple_state/addresser.rs
+++ b/sdk/src/simple_state/addresser.rs
@@ -98,3 +98,138 @@ impl Addresser<(String, String)> for DoubleKeyHashAddresser {
         keys.0.to_string() + "_" + &keys.1
     }
 }
+
+pub struct TripleKeyHashAddresser {
+    prefix: String,
+    first_hash_length: usize,
+    second_hash_length: usize,
+}
+
+impl TripleKeyHashAddresser {
+    pub fn new(
+        prefix: String,
+        first_hash_length: Option<usize>,
+        second_hash_length: Option<usize>,
+    ) -> TripleKeyHashAddresser {
+        let (first, second) =
+            calculate_hash_lengths(prefix.len(), first_hash_length, second_hash_length);
+        TripleKeyHashAddresser {
+            prefix,
+            first_hash_length: first,
+            second_hash_length: second,
+        }
+    }
+}
+
+impl Addresser<(String, String, String)> for TripleKeyHashAddresser {
+    fn compute(&self, keys: &(String, String, String)) -> Result<String, SimpleStateError> {
+        let hash_length = ADDRESS_LENGTH - self.prefix.len();
+        let last_hash_length = hash_length - (self.first_hash_length + self.second_hash_length);
+        if (self.prefix.len() + self.first_hash_length + self.second_hash_length + last_hash_length)
+            != ADDRESS_LENGTH
+        {
+            return Err(SimpleStateError::AddresserError(
+                "Incorrect hash length".to_string(),
+            ));
+        }
+
+        let first_hash = &hash(self.first_hash_length, &keys.0);
+        let second_hash = &hash(self.second_hash_length, &keys.1);
+        let third_hash = &hash(last_hash_length, &keys.2);
+
+        Ok(String::from(&self.prefix) + first_hash + second_hash + third_hash)
+    }
+
+    fn normalize(&self, keys: &(String, String, String)) -> String {
+        keys.0.to_string() + "_" + &keys.1 + "_" + &keys.2
+    }
+}
+
+// Used to calculate the lengths of the key hashes to be used to create an address by the
+// TripleKeyHashAddresser.
+fn calculate_hash_lengths(
+    prefix_length: usize,
+    first_length: Option<usize>,
+    second_length: Option<usize>,
+) -> (usize, usize) {
+    match (first_length, second_length) {
+        (Some(first), Some(second)) => (first, second),
+        (None, Some(second)) => (((ADDRESS_LENGTH - prefix_length - second) / 2), second),
+        (Some(first), None) => (first, ((ADDRESS_LENGTH - prefix_length - first) / 2)),
+        (None, None) => (
+            ((ADDRESS_LENGTH - prefix_length) / 3),
+            ((ADDRESS_LENGTH - prefix_length) / 3),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    // Tests the calculate_hash_lengths function using several different custom first hash lengths
+    // and `None` for the second length.
+    fn test_calculate_hash_custom_first_length() {
+        let (first_length, second_length) = calculate_hash_lengths(6, Some(21), None);
+        assert_eq!(first_length, 21);
+        assert_eq!(second_length, (43 / 2));
+
+        let (first_length, second_length) = calculate_hash_lengths(6, Some(41), None);
+        assert_eq!(first_length, 41);
+        assert_eq!(second_length, (23 / 2));
+
+        let (first_length, second_length) = calculate_hash_lengths(6, Some(61), None);
+        assert_eq!(first_length, 61);
+        assert_eq!(second_length, (3 / 2));
+    }
+
+    #[test]
+    // Tests the calculate_hash_lengths function using `None` for the first hash length and several
+    // custom values for the second length.
+    fn test_calculate_hash_custom_second_length() {
+        let (first_length, second_length) = calculate_hash_lengths(6, None, Some(21));
+        assert_eq!(first_length, (43 / 2));
+        assert_eq!(second_length, 21);
+
+        let (first_length, second_length) = calculate_hash_lengths(6, None, Some(41));
+        assert_eq!(first_length, (23 / 2));
+        assert_eq!(second_length, 41);
+
+        let (first_length, second_length) = calculate_hash_lengths(6, None, Some(61));
+        assert_eq!(first_length, (3 / 2));
+        assert_eq!(second_length, 61);
+    }
+
+    #[test]
+    // Tests the calculate_hash_lengths function using several different custom hash lengths.
+    fn test_calculate_hash_custom_lengths() {
+        let (first_length, second_length) = calculate_hash_lengths(6, Some(42), Some(12));
+        assert_eq!(first_length, 42);
+        assert_eq!(second_length, 12);
+
+        let (first_length, second_length) = calculate_hash_lengths(6, Some(12), Some(42));
+        assert_eq!(first_length, 12);
+        assert_eq!(second_length, 42);
+
+        let (first_length, second_length) = calculate_hash_lengths(6, Some(20), Some(20));
+        assert_eq!(first_length, 20);
+        assert_eq!(second_length, 20);
+    }
+
+    #[test]
+    // Tests the calculate_hash_lengths function using `None` for both hash lengths.
+    fn test_calculate_hash_no_custom_lengths() {
+        let (first_length, second_length) = calculate_hash_lengths(6, None, None);
+        assert_eq!(first_length, 21);
+        assert_eq!(second_length, 21);
+
+        let (first_length, second_length) = calculate_hash_lengths(30, None, None);
+        assert_eq!(first_length, (40 / 3));
+        assert_eq!(second_length, (40 / 3));
+
+        let (first_length, second_length) = calculate_hash_lengths(50, None, None);
+        assert_eq!(first_length, (20 / 3));
+        assert_eq!(second_length, (20 / 3));
+    }
+}

--- a/sdk/src/simple_state/addresser.rs
+++ b/sdk/src/simple_state/addresser.rs
@@ -14,6 +14,9 @@
 
 use crate::simple_state::error::SimpleStateError;
 
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
+
 pub const ADDRESS_LENGTH: usize = 70;
 
 pub trait Addresser<K> {
@@ -32,4 +35,32 @@ pub trait Addresser<K> {
     /// * `keys` - Contains natural keys
     ///
     fn normalize(&self, keys: &K) -> String;
+}
+
+fn hash(hash_length: usize, key: &str) -> String {
+    let mut sha = Sha512::new();
+    sha.input(key.as_bytes());
+    sha.result_str()[..hash_length].to_string()
+}
+
+pub struct KeyHashAddresser {
+    prefix: String,
+}
+
+impl KeyHashAddresser {
+    pub fn new(prefix: String) -> KeyHashAddresser {
+        KeyHashAddresser { prefix }
+    }
+}
+
+impl Addresser<String> for KeyHashAddresser {
+    fn compute(&self, keys: &String) -> Result<String, SimpleStateError> {
+        let hash_length = ADDRESS_LENGTH - self.prefix.len();
+
+        Ok(String::from(&self.prefix) + &hash(hash_length, keys))
+    }
+
+    fn normalize(&self, key: &String) -> String {
+        key.to_string()
+    }
 }

--- a/sdk/src/simple_state/context.rs
+++ b/sdk/src/simple_state/context.rs
@@ -1,0 +1,326 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use crate::protocol::simple_state::{
+    StateEntry, StateEntryBuilder, StateEntryList, StateEntryListBuilder, StateEntryValue,
+    StateEntryValueBuilder, ValueType,
+};
+use crate::protos::{FromBytes, IntoBytes};
+use crate::simple_state::addresser::Addresser;
+use crate::simple_state::error::SimpleStateError;
+use crate::TransactionContext;
+
+/// KeyValueTransactionContext used to implement a simplified state consisting
+/// of natural keys and a ValueType, an enum object used to represent a range primitive data types.
+/// Uses an implementation of the Addresser trait to calculate radix addresses to be stored in the
+/// KeyValueTransactionContext's internal transaction context.
+pub struct KeyValueTransactionContext<'a, A, K>
+where
+    A: Addresser<K>,
+{
+    context: &'a mut dyn TransactionContext,
+    addresser: A,
+    /// PhantomData<K> is necessary for the K generic to be used with the Addresser trait, as K is not
+    /// used in any other elements of the KeyValueTransactionContext struct.
+    _key: PhantomData<K>,
+}
+
+impl<'a, A, K> KeyValueTransactionContext<'a, A, K>
+where
+    A: Addresser<K>,
+    K: Eq + Hash,
+{
+    /// Creates a new KeyValueTransactionContext
+    /// Implementations of the TransactionContext trait and Addresser trait must be provided.
+    pub fn new(
+        context: &'a mut dyn TransactionContext,
+        addresser: A,
+    ) -> KeyValueTransactionContext<'a, A, K> {
+        KeyValueTransactionContext {
+            context,
+            addresser,
+            _key: PhantomData,
+        }
+    }
+
+    /// Calculates the address using the internal addresser then creates and serializes a
+    /// StateEntryList protobuf message to be stored in the internal transaction context as bytes.
+    ///
+    /// Returns an `Ok(())` if the entry is successfully stored.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The natural key to set the state entry at
+    /// * `values` - The HashMap to be stored in state at the provided natural key
+    pub fn set_state_entry(
+        &self,
+        key: &K,
+        values: HashMap<String, ValueType>,
+    ) -> Result<(), SimpleStateError> {
+        let mut new_entries = HashMap::new();
+        new_entries.insert(key, values);
+        self.set_state_entries(new_entries)
+    }
+
+    /// Calculates the address using the internal addresser and deserializes the data fetched into
+    /// a StateEntryList protobuf message, and translates this message to a HashMap, containing the
+    /// stored value.
+    ///
+    /// Returns an optional HashMap which representes the value stored in state, returning `None`
+    /// in case the address is not found.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The natural key to fetch
+    pub fn get_state_entry(
+        &self,
+        key: &K,
+    ) -> Result<Option<HashMap<String, ValueType>>, SimpleStateError> {
+        Ok(self
+            .get_state_entries(vec![key])?
+            .into_iter()
+            .map(|(_, val)| val)
+            .next())
+    }
+
+    /// Calculates the address using the internal addresser and retrieves the StateEntryList at the
+    /// specified address. Then, after ensuring the StateEntry with the matching normalized key as
+    /// the key provided, removes it from the StateEntryList. Then re-sets this filtered StateEntryList
+    /// back into state.
+    ///
+    /// Returns an optional normalized key of the successfully deleted state entry, returning
+    /// `None` if the StateEntryList or StateEntry is not found.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The natural key to delete
+    pub fn delete_state_entry(&self, key: K) -> Result<Option<String>, SimpleStateError> {
+        Ok(self.delete_state_entries(vec![key])?.into_iter().next())
+    }
+
+    /// For each value contained in the provided HashMap, creates and serializes a StateEntry
+    /// protobuf message to be stored in the internal transaction context as bytes at the associated
+    /// radix address that is calculated using the internal addresser.
+    ///
+    /// Returns an `Ok(())` if the provided entries were successfully stored.
+    ///
+    /// # Arguments
+    ///
+    /// * `entries` - Hashmap with the map to be stored in state at the associated natural key
+    pub fn set_state_entries(
+        &self,
+        entries: HashMap<&K, HashMap<String, ValueType>>,
+    ) -> Result<(), SimpleStateError> {
+        let keys = entries.keys().map(ToOwned::to_owned).collect::<Vec<&K>>();
+        let addresses = keys
+            .iter()
+            .map(|k| self.addresser.compute(&k))
+            .collect::<Result<Vec<String>, SimpleStateError>>()?;
+        // Creating a map of the StateEntryList to the address it is stored at
+        let entry_list_map = self.get_state_entry_lists(&addresses)?;
+
+        // Iterating over the provided HashMap to see if there is an existing StateEntryList at the
+        // corresponding address. If there is one found, add the new StateEntry to the StateEntryList.
+        // If there is none found, creates a new StateEntryList entry for that address.
+        // Then, serializes the newly created StateEntryList to be set in the internal context.
+        let entries_list = entries
+            .iter()
+            .map(|(key, values)| {
+                let addr = self.addresser.compute(key)?;
+                let state_entry = self.create_state_entry(key, values.to_owned())?;
+                match entry_list_map.get(&addr) {
+                    Some(entry_list) => {
+                        let mut existing_entries = entry_list.entries().to_vec();
+                        existing_entries.push(state_entry);
+                        let entry_list = StateEntryListBuilder::new()
+                            .with_state_entries(existing_entries)
+                            .build()
+                            .map_err(|err| SimpleStateError::ProtocolBuildError(Box::new(err)))?;
+                        Ok((addr, entry_list.into_bytes()?))
+                    }
+                    None => {
+                        let entry_list = StateEntryListBuilder::new()
+                            .with_state_entries(vec![state_entry])
+                            .build()
+                            .map_err(|err| SimpleStateError::ProtocolBuildError(Box::new(err)))?;
+                        Ok((addr, entry_list.into_bytes()?))
+                    }
+                }
+            })
+            .collect::<Result<Vec<(String, Vec<u8>)>, SimpleStateError>>()?;
+        self.context.set_state_entries(entries_list)?;
+
+        Ok(())
+    }
+
+    /// Calculates the addresses using the internal addresser and deserializes the data fetched into
+    /// a StateEntryList protobuf message, then collects the StateEntry objects held in each list
+    /// and translates these objects to the original HashMap value.
+    ///
+    /// Returns a HashMap of the normalized key to a HashMap of the value stored at the
+    /// corresponding radix address within the StateEntry with a matching normalized key.
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - A list of natural keys to be fetched from state
+    pub fn get_state_entries(
+        &self,
+        keys: Vec<&K>,
+    ) -> Result<HashMap<String, HashMap<String, ValueType>>, SimpleStateError> {
+        let addresses = keys
+            .iter()
+            .map(|k| self.addresser.compute(&k))
+            .collect::<Result<Vec<String>, SimpleStateError>>()?;
+        let normalized_keys = keys
+            .iter()
+            .map(|k| self.addresser.normalize(&k))
+            .collect::<Vec<String>>();
+
+        let state_entries: Vec<StateEntry> = self.flatten_state_entries(&addresses)?;
+
+        // Now going to filter the StateEntry objects that actually have a matching normalized
+        // key and convert the normalized key and value to be added to the returned HashMap.
+        state_entries
+            .iter()
+            .filter(|entry| normalized_keys.contains(&entry.normalized_key().to_string()))
+            .map(|entry| {
+                let values = entry
+                    .state_entry_values()
+                    .iter()
+                    .map(|val| (val.key().to_string(), val.value().to_owned()))
+                    .collect::<HashMap<String, ValueType>>();
+                Ok((entry.normalized_key().to_string(), values))
+            })
+            .collect::<Result<HashMap<String, HashMap<String, ValueType>>, SimpleStateError>>()
+    }
+
+    /// Fetches the relevant StateEntryLists, filters out any StateEntry objects with the matching
+    /// key, and then resets the updated StateEntryLists.
+    ///
+    /// Returns a list of normalized keys of successfully deleted state entries.
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - A list of natural keys to be deleted from state
+    pub fn delete_state_entries(&self, keys: Vec<K>) -> Result<Vec<String>, SimpleStateError> {
+        let key_map: HashMap<String, String> = keys
+            .iter()
+            .map(|k| Ok((self.addresser.normalize(k), self.addresser.compute(k)?)))
+            .collect::<Result<HashMap<String, String>, SimpleStateError>>()?;
+        let state_entry_lists: HashMap<String, StateEntryList> = self.get_state_entry_lists(
+            &key_map
+                .values()
+                .map(ToOwned::to_owned)
+                .collect::<Vec<String>>(),
+        )?;
+
+        let mut deleted_keys = Vec::new();
+        let mut new_entry_lists = Vec::new();
+        let mut delete_lists = Vec::new();
+        key_map.iter().for_each(|(nkey, addr)| {
+            // Fetching the StateEntryList at the corresponding address
+            if let Some(list) = state_entry_lists.get(addr) {
+                // The StateEntry objects will be filtered out of the StateEntryList if it has the
+                // normalized key. This normalized key is added to a list of successfully filtered
+                // entries to be returned.
+                if list.contains(nkey.to_string()) {
+                    let filtered = list
+                        .entries()
+                        .to_vec()
+                        .into_iter()
+                        .filter(|e| e.normalized_key() != nkey)
+                        .collect::<Vec<StateEntry>>();
+                    if filtered.is_empty() {
+                        delete_lists.push(addr.to_string());
+                    } else {
+                        new_entry_lists.push((addr.to_string(), filtered));
+                    }
+                    deleted_keys.push(nkey.to_string());
+                }
+            }
+        });
+        // Delete any StateEntryLists that have an empty list of entries
+        self.context.delete_state_entries(delete_lists.as_slice())?;
+        // Setting the newly filtered StateEntryLists into state using the internal context
+        self.context.set_state_entries(
+            new_entry_lists
+                .iter()
+                .map(|(addr, filtered_list)| {
+                    let new_entry_list = StateEntryListBuilder::new()
+                        .with_state_entries(filtered_list.to_vec())
+                        .build()
+                        .map_err(|err| SimpleStateError::ProtocolBuildError(Box::new(err)))?;
+                    Ok((addr.to_string(), new_entry_list.into_bytes()?))
+                })
+                .collect::<Result<Vec<(String, Vec<u8>)>, SimpleStateError>>()?,
+        )?;
+
+        Ok(deleted_keys)
+    }
+
+    /// Collects the StateEntryList objects from state and then uses flat_map
+    /// to collect the StateEntry objects held within each StateEntryList.
+    fn flatten_state_entries(
+        &self,
+        addresses: &[String],
+    ) -> Result<Vec<StateEntry>, SimpleStateError> {
+        Ok(self
+            .get_state_entry_lists(addresses)?
+            .values()
+            .flat_map(|entry_list| entry_list.entries().to_vec())
+            .collect::<Vec<StateEntry>>())
+    }
+
+    /// Collects the StateEntryList objects from the bytes fetched from state,
+    /// then deserializes these into the native StateEntryList object
+    fn get_state_entry_lists(
+        &self,
+        addresses: &[String],
+    ) -> Result<HashMap<String, StateEntryList>, SimpleStateError> {
+        self.context
+            .get_state_entries(&addresses)?
+            .iter()
+            .map(|(addr, bytes_entry)| {
+                Ok((addr.to_string(), StateEntryList::from_bytes(bytes_entry)?))
+            })
+            .collect::<Result<HashMap<String, StateEntryList>, SimpleStateError>>()
+    }
+
+    /// Creates a singular StateEntry object from the provided key and values.
+    fn create_state_entry(
+        &self,
+        key: &K,
+        values: HashMap<String, ValueType>,
+    ) -> Result<StateEntry, SimpleStateError> {
+        let state_values: Vec<StateEntryValue> = values
+            .iter()
+            .map(|(key, value)| {
+                StateEntryValueBuilder::new()
+                    .with_key(key.to_string())
+                    .with_value(value.clone())
+                    .build()
+                    .map_err(|err| SimpleStateError::ProtocolBuildError(Box::new(err)))
+            })
+            .collect::<Result<Vec<StateEntryValue>, SimpleStateError>>()?;
+        Ok(StateEntryBuilder::new()
+            .with_normalized_key(self.addresser.normalize(key.to_owned()))
+            .with_state_entry_values(state_values)
+            .build()
+            .map_err(|err| SimpleStateError::ProtocolBuildError(Box::new(err)))?)
+    }
+}

--- a/sdk/src/simple_state/error.rs
+++ b/sdk/src/simple_state/error.rs
@@ -14,12 +14,16 @@
 
 use std::error::Error as StdError;
 
+use crate::WasmSdkError;
+
 use crate::protos::ProtoConversionError;
 
 #[derive(Debug)]
 pub enum SimpleStateError {
     AddresserError(String),
     ProtoConversionError(ProtoConversionError),
+    ProtocolBuildError(Box<dyn StdError>),
+    SdkError(WasmSdkError),
 }
 
 impl std::fmt::Display for SimpleStateError {
@@ -29,6 +33,10 @@ impl std::fmt::Display for SimpleStateError {
             SimpleStateError::ProtoConversionError(ref err) => {
                 write!(f, "ProtoConversionError: {}", err.description())
             }
+            SimpleStateError::ProtocolBuildError(ref err) => {
+                write!(f, "ProtocolBuildError: {}", err.description())
+            }
+            SimpleStateError::SdkError(ref err) => write!(f, "WasmSdkError: {}", err.to_string()),
         }
     }
 }
@@ -36,5 +44,11 @@ impl std::fmt::Display for SimpleStateError {
 impl From<ProtoConversionError> for SimpleStateError {
     fn from(e: ProtoConversionError) -> Self {
         SimpleStateError::ProtoConversionError(e)
+    }
+}
+
+impl From<WasmSdkError> for SimpleStateError {
+    fn from(e: WasmSdkError) -> Self {
+        SimpleStateError::SdkError(e)
     }
 }

--- a/sdk/src/simple_state/error.rs
+++ b/sdk/src/simple_state/error.rs
@@ -1,0 +1,40 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+
+use crate::protos::ProtoConversionError;
+
+#[derive(Debug)]
+pub enum SimpleStateError {
+    AddresserError(String),
+    ProtoConversionError(ProtoConversionError),
+}
+
+impl std::fmt::Display for SimpleStateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            SimpleStateError::AddresserError(ref s) => write!(f, "AddresserError: {}", s),
+            SimpleStateError::ProtoConversionError(ref err) => {
+                write!(f, "ProtoConversionError: {}", err.description())
+            }
+        }
+    }
+}
+
+impl From<ProtoConversionError> for SimpleStateError {
+    fn from(e: ProtoConversionError) -> Self {
+        SimpleStateError::ProtoConversionError(e)
+    }
+}

--- a/sdk/src/simple_state/mod.rs
+++ b/sdk/src/simple_state/mod.rs
@@ -15,3 +15,289 @@
 pub mod addresser;
 pub mod context;
 pub mod error;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use crate::protocol::simple_state::ValueType;
+    use crate::{TransactionContext, WasmSdkError};
+
+    use addresser::KeyHashAddresser;
+    use context::KeyValueTransactionContext;
+    use error::SimpleStateError;
+
+    struct TestState {
+        state: HashMap<String, Vec<u8>>,
+    }
+
+    impl TestState {
+        pub fn new() -> Self {
+            TestState {
+                state: HashMap::new(),
+            }
+        }
+
+        fn get_entries(
+            &self,
+            addresses: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, SimpleStateError> {
+            let mut values = Vec::new();
+            addresses.iter().for_each(|key| {
+                if let Some(value) = self.state.get(key) {
+                    values.push((key.to_string(), value.to_vec()))
+                }
+            });
+            Ok(values)
+        }
+
+        fn set_entries(&mut self, entries: Vec<(String, Vec<u8>)>) -> Result<(), SimpleStateError> {
+            entries.iter().for_each(|(key, value)| {
+                match self.state.insert(key.to_string(), value.to_vec()) {
+                    _ => (),
+                }
+            });
+            Ok(())
+        }
+
+        fn delete_entries(
+            &mut self,
+            addresses: &[String],
+        ) -> Result<Vec<String>, SimpleStateError> {
+            let mut deleted = Vec::new();
+            addresses.iter().for_each(|key| {
+                if let Some(_) = self.state.remove(key) {
+                    deleted.push(key.to_string());
+                }
+            });
+            Ok(deleted)
+        }
+    }
+
+    struct TestContext {
+        internal_state: Arc<Mutex<TestState>>,
+    }
+
+    impl TestContext {
+        pub fn new() -> Self {
+            TestContext {
+                internal_state: Arc::new(Mutex::new(TestState::new())),
+            }
+        }
+    }
+
+    impl TransactionContext for TestContext {
+        fn get_state_entries(
+            &self,
+            addresses: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, WasmSdkError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in get method")
+                .get_entries(addresses)
+                .map_err(|err| {
+                    WasmSdkError::InternalError(format!(
+                        "Unable to get state entries: {}",
+                        err.to_string(),
+                    ))
+                })
+        }
+
+        fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), WasmSdkError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in set method")
+                .set_entries(entries)
+                .map_err(|err| {
+                    WasmSdkError::InternalError(format!(
+                        "Unable to get state entries: {}",
+                        err.to_string(),
+                    ))
+                })
+        }
+
+        fn delete_state_entries(&self, addresses: &[String]) -> Result<Vec<String>, WasmSdkError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in delete method")
+                .delete_entries(addresses)
+                .map_err(|err| {
+                    WasmSdkError::InternalError(format!(
+                        "Unable to get state entries: {}",
+                        err.to_string(),
+                    ))
+                })
+        }
+    }
+
+    fn create_entry_value_map(key: String, value: ValueType) -> HashMap<String, ValueType> {
+        let mut value_map = HashMap::new();
+        value_map.insert(key, value);
+        value_map
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext set_state_entry method successfully sets
+    // the state entry. Uses the KeyHashAddresser implementation.
+    fn test_simple_set_state_entry() {
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let value = ValueType::Int32(32);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        assert!(simple_state
+            .set_state_entry(&"a".to_string(), state_value)
+            .is_ok());
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext get_state_entry method successfully fetches
+    // the correct state entry. Uses the KeyHashAddresser implementation.
+    fn test_simple_get_state_entry() {
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let value = ValueType::Int32(32);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+        simple_state
+            .set_state_entry(&"a".to_string(), state_value)
+            .expect("Unable to set state entry in get_state_entry test");
+
+        let values = simple_state.get_state_entry(&"a".to_string()).unwrap();
+        assert!(values.is_some());
+        assert_eq!(
+            values.unwrap().get(&"key1".to_string()),
+            Some(&ValueType::Int32(32))
+        );
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext delete_state_entry method successfully deletes
+    // the state entry. Uses the KeyHashAddresser implementation.
+    fn test_simple_delete_state_entry() {
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let value = ValueType::Int32(32);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        simple_state
+            .set_state_entry(&"a".to_string(), state_value)
+            .expect("Unable to set state entry in delete_state_entry test");
+
+        simple_state
+            .get_state_entry(&"a".to_string())
+            .expect("Unable to get state entry in delete_state_entries test");
+
+        let deleted = simple_state.delete_state_entry("a".to_string()).unwrap();
+        assert!(deleted.is_some());
+        assert_eq!(deleted, Some("a".to_string()));
+
+        let already_deleted = simple_state.delete_state_entry("a".to_string()).unwrap();
+        assert!(already_deleted.is_none());
+        let deleted_value = simple_state.get_state_entry(&"a".to_string()).unwrap();
+        assert!(deleted_value.is_none());
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext set_state_entries method successfully sets
+    // the state entries. Uses the KeyHashAddresser implementation.
+    fn test_simple_set_state_entries() {
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let mut entries = HashMap::new();
+
+        let first_key = &"a".to_string();
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &"b".to_string();
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        entries.insert(first_key, first_value_map);
+        entries.insert(second_key, second_value_map);
+
+        let set_result = simple_state.set_state_entries(entries);
+        assert!(set_result.is_ok());
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext get_state_entries method successfully gets
+    // the state entries. Uses the KeyHashAddresser implementation.
+    fn test_simple_get_state_entries() {
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let mut entries = HashMap::new();
+
+        let first_key = &"a".to_string();
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &"b".to_string();
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        entries.insert(first_key, first_value_map.clone());
+        entries.insert(second_key, second_value_map.clone());
+
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set state entries in get_state_entries test");
+
+        let values = simple_state
+            .get_state_entries([first_key, second_key].to_vec())
+            .unwrap();
+        assert_eq!(values.get("a").unwrap(), &first_value_map);
+        assert_eq!(values.get("b").unwrap(), &second_value_map);
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext delete_state_entries method successfully deletes
+    // the state entries. Uses the KeyHashAddresser implementation.
+    fn test_simple_delete_state_entries() {
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let mut entries = HashMap::new();
+
+        let first_key = &"a".to_string();
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &"b".to_string();
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        entries.insert(first_key, first_value_map.clone());
+        entries.insert(second_key, second_value_map.clone());
+
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set state entries in get_state_entries test");
+
+        simple_state
+            .get_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to get state entries in delete_state_entries test");
+
+        let deleted = simple_state
+            .delete_state_entries(["a".to_string(), "b".to_string()].to_vec())
+            .expect("Unable to delete state entries");
+        assert!(deleted.contains(&"a".to_string()));
+        assert!(deleted.contains(&"b".to_string()));
+
+        let already_deleted = simple_state
+            .delete_state_entries(["a".to_string(), "b".to_string()].to_vec())
+            .unwrap();
+        assert!(already_deleted.is_empty());
+    }
+}

--- a/sdk/src/simple_state/mod.rs
+++ b/sdk/src/simple_state/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod error;

--- a/sdk/src/simple_state/mod.rs
+++ b/sdk/src/simple_state/mod.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 pub mod addresser;
+pub mod context;
 pub mod error;

--- a/sdk/src/simple_state/mod.rs
+++ b/sdk/src/simple_state/mod.rs
@@ -26,7 +26,7 @@ mod tests {
     use crate::protocol::simple_state::ValueType;
     use crate::{TransactionContext, WasmSdkError};
 
-    use addresser::KeyHashAddresser;
+    use addresser::{DoubleKeyHashAddresser, KeyHashAddresser};
     use context::KeyValueTransactionContext;
     use error::SimpleStateError;
 
@@ -299,5 +299,155 @@ mod tests {
             .delete_state_entries(["a".to_string(), "b".to_string()].to_vec())
             .unwrap();
         assert!(already_deleted.is_empty());
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext set_state_entry method successfully sets
+    // the correct state entry. Uses the DoubleKeyHashAddresser implementation.
+    fn test_double_set_state_entry() {
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        assert!(simple_state
+            .set_state_entry(&("a".to_string(), "b".to_string()), state_value)
+            .is_ok());
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext get_state_entry method successfully gets
+    // the correct state entry. Uses the DoubleKeyHashAddresser implementation.
+    fn test_double_get_state_entry() {
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+        simple_state
+            .set_state_entry(&("a".to_string(), "b".to_string()), state_value)
+            .expect("Unable to set state entry in get_state_entry test");
+
+        let values = simple_state
+            .get_state_entry(&("a".to_string(), "b".to_string()))
+            .unwrap();
+        assert!(values.is_some());
+        assert_eq!(
+            values.unwrap().get(&"key1".to_string()),
+            Some(&ValueType::Int64(64))
+        );
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext delete_state_entry method successfully deletes
+    // the state entry. Uses the DoubleKeyHashAddresser implementation.
+    fn test_double_delete_state_entry() {
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+        simple_state
+            .set_state_entry(&("a".to_string(), "b".to_string()), state_value)
+            .expect("Unable to set state entry in get_state_entry test");
+        simple_state
+            .get_state_entry(&("a".to_string(), "b".to_string()))
+            .expect("Unable to get state entry in delete_state_entries test");
+
+        let deleted = simple_state
+            .delete_state_entry(("a".to_string(), "b".to_string()))
+            .unwrap();
+        assert!(deleted.is_some());
+        assert_eq!(deleted, Some(format!("{}_{}", "a", "b")));
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext set_state_entries method successfully sets
+    // the state entries. Uses the DoubleKeyHashAddresser implementation.
+    fn test_double_set_state_entries() {
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let mut entries = HashMap::new();
+        let first_key = &("a".to_string(), "b".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &("c".to_string(), "d".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+        entries.insert(first_key, first_value_map);
+        entries.insert(second_key, second_value_map);
+
+        assert!(simple_state.set_state_entries(entries).is_ok());
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext get_state_entries method successfully gets
+    // the state entries. Uses the DoubleKeyHashAddresser implementation.
+    fn test_double_get_state_entries() {
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let mut entries = HashMap::new();
+        let first_key = &("a".to_string(), "b".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &("c".to_string(), "d".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+        entries.insert(first_key, first_value_map.clone());
+        entries.insert(second_key, second_value_map.clone());
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set_state_entries in get_state_entries test");
+
+        let values = simple_state
+            .get_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to get state entries in get_state_entries test");
+        assert_eq!(
+            values.get(&format!("{}_{}", "a", "b")).unwrap(),
+            &first_value_map
+        );
+        assert_eq!(
+            values.get(&format!("{}_{}", "c", "d")).unwrap(),
+            &second_value_map
+        );
+    }
+
+    #[test]
+    // Check that the KeyValueTransactionContext delete_state_entries method successfully deletes
+    // the state entries. Uses the DoubleKeyHashAddresser implementation.
+    fn test_double_delete_state_entries() {
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        let mut entries = HashMap::new();
+        let first_key = ("a".to_string(), "b".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = ("c".to_string(), "d".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+        entries.insert(&first_key, first_value_map.clone());
+        entries.insert(&second_key, second_value_map.clone());
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set_state_entries in delete_state_entries test");
+        simple_state
+            .get_state_entries([&first_key, &second_key].to_vec())
+            .expect("Unable to get_state_entries in the delete_state_entries test");
+
+        let deleted = simple_state
+            .delete_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to delete state entries");
+        assert!(deleted.contains(&format!("{}_{}", "a", "b")));
+        assert!(deleted.contains(&format!("{}_{}", "c", "d")));
     }
 }


### PR DESCRIPTION
Adds implementation and unit tests for a simplified transaction context and a new Addresser trait. 

Came from here: https://github.com/hyperledger/sawtooth-sabre/pull/87, now following the correct process through the Cargill Sabre fork. All comments had been addressed from the requested changes before closing.