### PR TITLE
Increment version to v0.5.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,29 @@
+# Release Notes
+
+## Changes in Sawtooth Sabre 0.5
+
+### Highlights
+
+* Add AssemblyScript SDK for smart contracts with an example "incdec" smart
+  contract
+* Add important address prefixes and address computation functions to the Rust
+  SDK
+* Add `into_payload_builder` methods to each `*ActionBuilder` in the Rust SDK
+* Add `into_transaction_builder` method to `SabrePayloadBuilder` in the Rust SDK
+
+### Breaking Changes
+
+* Update all `*ActionBuilder` structs to use a single, common `ActionBuildError`
+
+### Other Changes
+* Package intkey_multiply example smart contract as .scar file
+* Add an optional argument to the `sabre upload` CLI command for manually
+  specifying the path of a .wasm contract
+* Remove an unnecessary unwrap in the transaction processor library
+* Use stable Rust instead of nightly for the sabre integration dockerfile
+* Fix typos in the documentation
+* Add safety warnings for unsafe functions
+* Return a response when waiting for batch in CLI
+* Update all Docker Compose files to pull latest Docker images for Sawtooth
+* Implement `From<*Action>` traits for all `*Action` structs on the `Action`
+  struct in the Rust SDK

--- a/docs/source/version_compatibility.rst
+++ b/docs/source/version_compatibility.rst
@@ -49,3 +49,9 @@ the Sabre transaction processor image.
 |            |          |           |         |   Sabre Transaction Processor  |
 |            |          |           |         |   where it will be logged.     |
 +------------+----------+-----------+---------+--------------------------------+
+| 0.5        | 0.5      | 0.5       |  0.3    | - Replaces all `*ActionBuilder`|
+|            |          |           |         |   errors with a single         |
+|            |          |           |         |   ActionBuildError and adds the|
+|            |          |           |         |   `into_payload_builder` method|
+|            |          |           |         |   to all `*ActionBuilders`.    |
++------------+----------+-----------+---------+--------------------------------+


### PR DESCRIPTION
This is required due to a breaking change in 64a29d3.

Signed-off-by: Logan Seeley <seeley@bitwise.io>
