### PR TITLE
Add event capability to the Sabre SDK

### DIFF
--- a/example/intkey_multiply/processor/src/handler.rs
+++ b/example/intkey_multiply/processor/src/handler.rs
@@ -610,9 +610,17 @@ impl TransactionHandler for IntkeyMultiplyTransactionHandler {
                 new_value
             )));
         };
-        state.set(&payload.get_name_a(), new_value as u32)
+        state.set(&payload.get_name_a(), new_value as u32)?;
+
+        // Send an event with the result and the current values of b & c
+        // Compute the event data to be sent in Bvalue,Cvalue,Avalue format
+        let values = format!("{},{},{}", orig_value_b, orig_value_c, new_value);
+        context
+            .add_event(String::from("computation"), Vec::new(), values.as_bytes())
+            .map_err(ApplyError::from)
     }
 }
+
 #[cfg(target_arch = "wasm32")]
 fn run_smart_permisson(signer: &str, payload: &[u8], agent: Agent) -> Result<i32, ApplyError> {
     let org_id = agent.org_id();

--- a/sdks/rust/src/externs.rs
+++ b/sdks/rust/src/externs.rs
@@ -20,6 +20,11 @@ extern "C" {
     pub fn get_state(addresses: WasmPtrList) -> WasmPtrList;
     pub fn set_state(addr_data: WasmPtrList) -> i32;
     pub fn delete_state(addresses: WasmPtrList) -> WasmPtrList;
+    pub fn add_event(
+        event_type: WasmPtr,
+        attributes: WasmPtrList,
+        data: WasmPtr,
+    ) -> i32;
     pub fn get_ptr_len(ptr: WasmPtr) -> isize;
     pub fn alloc(len: usize) -> WasmPtr;
     pub fn read_byte(offset: isize) -> u8;

--- a/tp/src/wasm_executor/wasm_externals.rs
+++ b/tp/src/wasm_executor/wasm_externals.rs
@@ -226,8 +226,18 @@ impl<'a> WasmExternals<'a> {
 
         let raw_ptr = ptr.raw;
 
+        // In case the data to be added is empty, keep the memory_write_offset
+        // moving to the next location.
+        let offset_to_add = if data.capacity() == 0 {
+            1 as u32
+        } else {
+            data.capacity() as u32
+        };
+
         self.ptrs.insert(self.memory_write_offset, ptr);
-        self.memory_write_offset += data.capacity() as u32;
+        self.memory_write_offset += offset_to_add;
+
+        debug!("moved the pointer to {:?}", self.memory_write_offset);
 
         Ok(raw_ptr)
     }

--- a/tp/src/wasm_executor/wasm_externals.rs
+++ b/tp/src/wasm_executor/wasm_externals.rs
@@ -450,7 +450,7 @@ impl<'a> WasmExternals<'a> {
                 Ok(Some(RuntimeValue::I32(1)))
             }
             Err(err) => {
-                info!("Set Error: {}", err);
+                error!("Set Error: {}", err);
                 info!(
                     "SET_STATE Execution time: {} secs {} ms",
                     timer.elapsed().as_secs(),


### PR DESCRIPTION
1. Add a new method to the TransactionContext to match that of sawtooth-sdk's TransactionContext for the add_event().
2. Implement TransactionContext method for the Wasm
3. Expose add_event method from the WasmExecutor.