### PR TITLE
SabrePayloadBuilder into TransactionBuilder

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -27,6 +27,7 @@ edition = "2018"
 
 [dependencies]
 protobuf = "2"
+sha2 = "0.8"
 
 [build-dependencies]
 protoc-rust = "2"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -29,6 +29,9 @@ edition = "2018"
 protobuf = "2"
 sha2 = "0.8"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+transact = "0.2"
+
 [build-dependencies]
 protoc-rust = "2"
 glob = "0.2"

--- a/sdks/rust/src/protocol/mod.rs
+++ b/sdks/rust/src/protocol/mod.rs
@@ -16,6 +16,138 @@ pub mod payload;
 pub mod pike;
 pub mod state;
 
+use std::error::Error;
+
+use sha2::{Digest, Sha512};
+
 pub const ADMINISTRATORS_SETTING_ADDRESS: &str =
     "000000a87cb5eafdcca6a814e4add97c4b517d3c530c2f44b31d18e3b0c44298fc1c14";
 pub const ADMINISTRATORS_SETTING_KEY: &str = "sawtooth.swa.administrators";
+
+pub const NAMESPACE_REGISTRY_ADDRESS_PREFIX: &str = "00ec00";
+pub const CONTRACT_REGISTRY_ADDRESS_PREFIX: &str = "00ec01";
+pub const CONTRACT_ADDRESS_PREFIX: &str = "00ec02";
+pub const SMART_PERMISSION_ADDRESS_PREFIX: &str = "00ec03";
+pub const AGENT_ADDRESS_PREFIX: &str = "cad11d00";
+pub const ORG_ADDRESS_PREFIX: &str = "cad11d01";
+
+/// Compute a state address for a given namespace registry.
+///
+/// # Arguments
+///
+/// * `namespace` - the address prefix for this namespace
+pub fn compute_namespace_registry_address(namespace: &str) -> Result<Vec<u8>, AddressingError> {
+    let prefix = match namespace.get(..6) {
+        Some(x) => x,
+        None => {
+            return Err(AddressingError::InvalidInput(format!(
+                "namespace '{}' is less than 6 characters long",
+                namespace,
+            )));
+        }
+    };
+    let hash = sha512_hash(prefix.as_bytes());
+    Ok([&parse_hex(NAMESPACE_REGISTRY_ADDRESS_PREFIX)?, &hash[..64]].concat())
+}
+
+/// Compute a state address for a given contract registry.
+///
+/// # Arguments
+///
+/// * `name` - the name of the contract registry
+pub fn compute_contract_registry_address(name: &str) -> Result<Vec<u8>, AddressingError> {
+    let hash = sha512_hash(name.as_bytes());
+    Ok([&parse_hex(CONTRACT_REGISTRY_ADDRESS_PREFIX)?, &hash[..64]].concat())
+}
+
+/// Compute a state address for a given contract.
+///
+/// # Arguments
+///
+/// * `name` - the name of the contract
+/// * `version` - the version of the contract
+pub fn compute_contract_address(name: &str, version: &str) -> Result<Vec<u8>, AddressingError> {
+    let s = String::from(name) + "," + version;
+    let hash = sha512_hash(s.as_bytes());
+    Ok([&parse_hex(CONTRACT_ADDRESS_PREFIX)?, &hash[..64]].concat())
+}
+
+/// Compute a state address for a given smart permission.
+///
+/// # Arguments
+///
+/// * `org_id` - the organization's id
+/// * `name` - smart permission name
+pub fn compute_smart_permission_address(
+    org_id: &str,
+    name: &str,
+) -> Result<Vec<u8>, AddressingError> {
+    let org_id_hash = sha512_hash(org_id.as_bytes());
+    let name_hash = sha512_hash(name.as_bytes());
+    Ok([
+        &parse_hex(SMART_PERMISSION_ADDRESS_PREFIX)?,
+        &org_id_hash[..6],
+        &name_hash[..58],
+    ]
+    .concat())
+}
+
+/// Compute a state address for a given agent name.
+///
+/// # Arguments
+///
+/// * `name` - the agent's name
+pub fn compute_agent_address(name: &[u8]) -> Result<Vec<u8>, AddressingError> {
+    let hash = sha512_hash(name);
+    Ok([&parse_hex(AGENT_ADDRESS_PREFIX)?, &hash[..62]].concat())
+}
+
+/// Compute a state address for a given organization id.
+///
+/// # Arguments
+///
+/// * `id` - the organization's id
+pub fn compute_org_address(id: &str) -> Result<Vec<u8>, AddressingError> {
+    let hash = sha512_hash(id.as_bytes());
+    Ok([&parse_hex(ORG_ADDRESS_PREFIX)?, &hash[..62]].concat())
+}
+
+fn sha512_hash(bytes: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha512::new();
+    hasher.input(bytes);
+    hasher.result().to_vec()
+}
+
+/// Convert a hex string to bytes.
+fn parse_hex(hex: &str) -> Result<Vec<u8>, AddressingError> {
+    if hex.len() % 2 != 0 {
+        return Err(AddressingError::InvalidInput(format!(
+            "hex string has odd number of digits: {}",
+            hex
+        )));
+    }
+
+    let mut res = vec![];
+    for i in (0..hex.len()).step_by(2) {
+        res.push(u8::from_str_radix(&hex[i..i + 2], 16).map_err(|_| {
+            AddressingError::InvalidInput(format!("string contains invalid hex: {}", hex))
+        })?);
+    }
+
+    Ok(res)
+}
+
+#[derive(Debug)]
+pub enum AddressingError {
+    InvalidInput(String),
+}
+
+impl Error for AddressingError {}
+
+impl std::fmt::Display for AddressingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            AddressingError::InvalidInput(msg) => write!(f, "addressing input is invalid: {}", msg),
+        }
+    }
+}

--- a/sdks/rust/src/protocol/payload.rs
+++ b/sdks/rust/src/protocol/payload.rs
@@ -2186,7 +2186,7 @@ impl SabrePayloadBuilder {
 
     pub fn build(self) -> Result<SabrePayload, SabrePayloadBuildError> {
         let action = self.action.ok_or_else(|| {
-            SabrePayloadBuildError::MissingField("'name' field is required".to_string())
+            SabrePayloadBuildError::MissingField("'action' field is required".to_string())
         })?;
 
         Ok(SabrePayload { action })

--- a/sdks/rust/src/protocol/payload.rs
+++ b/sdks/rust/src/protocol/payload.rs
@@ -14,12 +14,25 @@
 
 use protobuf::Message;
 use protobuf::RepeatedField;
+#[cfg(not(target_arch = "wasm32"))]
+use transact::{
+    protocol::transaction::{HashMethod, TransactionBuilder},
+    signing::Signer,
+};
 
 use std::error::Error as StdError;
 
 use crate::protos;
 use crate::protos::{
     FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+
+use super::AddressingError;
+#[cfg(not(target_arch = "wasm32"))]
+use super::{
+    compute_agent_address, compute_contract_address, compute_contract_registry_address,
+    compute_namespace_registry_address, compute_org_address, compute_smart_permission_address,
+    parse_hex, ADMINISTRATORS_SETTING_ADDRESS,
 };
 
 /// Native implementation for SabrePayload_Action
@@ -2149,13 +2162,19 @@ impl IntoNative<SabrePayload> for protos::payload::SabrePayload {}
 
 #[derive(Debug)]
 pub enum SabrePayloadBuildError {
+    AddressingError(String),
+    InvalidAction(String),
     MissingField(String),
+    ProtoConversionError(String),
 }
 
 impl StdError for SabrePayloadBuildError {
     fn description(&self) -> &str {
         match *self {
+            SabrePayloadBuildError::AddressingError(ref msg) => msg,
+            SabrePayloadBuildError::InvalidAction(ref msg) => msg,
             SabrePayloadBuildError::MissingField(ref msg) => msg,
+            SabrePayloadBuildError::ProtoConversionError(ref msg) => msg,
         }
     }
 }
@@ -2163,8 +2182,19 @@ impl StdError for SabrePayloadBuildError {
 impl std::fmt::Display for SabrePayloadBuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
+            SabrePayloadBuildError::AddressingError(ref s) => write!(f, "AddressingError: {}", s),
+            SabrePayloadBuildError::InvalidAction(ref s) => write!(f, "InvalidAction: {}", s),
             SabrePayloadBuildError::MissingField(ref s) => write!(f, "MissingField: {}", s),
+            SabrePayloadBuildError::ProtoConversionError(ref s) => {
+                write!(f, "ProtoConversionError: {}", s)
+            }
         }
+    }
+}
+
+impl From<AddressingError> for SabrePayloadBuildError {
+    fn from(err: AddressingError) -> Self {
+        Self::AddressingError(err.to_string())
     }
 }
 
@@ -2191,11 +2221,140 @@ impl SabrePayloadBuilder {
 
         Ok(SabrePayload { action })
     }
+
+    /// Convert the `SabrePayloadBuilder` into a `TransactionBuilder`, filling in all required
+    /// fields.
+    ///
+    /// NOTE: a signer is required because some input/output addresses of smart permission payloads
+    /// are calculated using the signer's public key.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn into_transaction_builder(
+        self,
+        signer: &dyn Signer,
+    ) -> Result<TransactionBuilder, SabrePayloadBuildError> {
+        let payload = self.build()?;
+
+        let (input_addresses, output_addresses) = match payload.action() {
+            Action::CreateContract(CreateContractAction { name, version, .. })
+            | Action::DeleteContract(DeleteContractAction { name, version, .. }) => {
+                let addresses = vec![
+                    compute_contract_registry_address(&name)?,
+                    compute_contract_address(&name, &version)?,
+                ];
+                (addresses.clone(), addresses)
+            }
+            Action::ExecuteContract(ExecuteContractAction {
+                name,
+                version,
+                inputs,
+                outputs,
+                ..
+            }) => {
+                let addresses = vec![
+                    compute_contract_registry_address(&name)?,
+                    compute_contract_address(&name, &version)?,
+                ];
+
+                let mut input_addresses = addresses.clone();
+                for input in inputs {
+                    let namespace = match input.get(..6) {
+                        Some(namespace) => namespace,
+                        None => {
+                            return Err(SabrePayloadBuildError::InvalidAction(format!(
+                                "invalid input: '{}' is less than 6 characters long",
+                                input,
+                            )));
+                        }
+                    };
+                    input_addresses.push(compute_namespace_registry_address(namespace)?);
+                    input_addresses.push(parse_hex(&input)?);
+                }
+
+                let mut output_addresses = addresses;
+                for output in outputs {
+                    let namespace = match output.get(..6) {
+                        Some(namespace) => namespace,
+                        None => {
+                            return Err(SabrePayloadBuildError::InvalidAction(format!(
+                                "invalid output: '{}' is less than 6 characters long",
+                                output,
+                            )));
+                        }
+                    };
+                    output_addresses.push(compute_namespace_registry_address(namespace)?);
+                    output_addresses.push(parse_hex(&output)?);
+                }
+
+                (input_addresses, output_addresses)
+            }
+            Action::CreateContractRegistry(CreateContractRegistryAction { name, .. })
+            | Action::DeleteContractRegistry(DeleteContractRegistryAction { name, .. })
+            | Action::UpdateContractRegistryOwners(UpdateContractRegistryOwnersAction {
+                name,
+                ..
+            }) => {
+                let addresses = vec![
+                    compute_contract_registry_address(&name)?,
+                    ADMINISTRATORS_SETTING_ADDRESS.into(),
+                ];
+                (addresses.clone(), addresses)
+            }
+            Action::CreateNamespaceRegistry(CreateNamespaceRegistryAction {
+                namespace, ..
+            })
+            | Action::DeleteNamespaceRegistry(DeleteNamespaceRegistryAction {
+                namespace, ..
+            })
+            | Action::UpdateNamespaceRegistryOwners(UpdateNamespaceRegistryOwnersAction {
+                namespace,
+                ..
+            })
+            | Action::CreateNamespaceRegistryPermission(
+                CreateNamespaceRegistryPermissionAction { namespace, .. },
+            )
+            | Action::DeleteNamespaceRegistryPermission(
+                DeleteNamespaceRegistryPermissionAction { namespace, .. },
+            ) => {
+                let addresses = vec![
+                    compute_namespace_registry_address(&namespace)?,
+                    ADMINISTRATORS_SETTING_ADDRESS.into(),
+                ];
+                (addresses.clone(), addresses)
+            }
+            Action::CreateSmartPermission(CreateSmartPermissionAction { org_id, name, .. })
+            | Action::UpdateSmartPermission(UpdateSmartPermissionAction { org_id, name, .. })
+            | Action::DeleteSmartPermission(DeleteSmartPermissionAction { org_id, name, .. }) => {
+                let addresses = vec![
+                    compute_smart_permission_address(&org_id, &name)?,
+                    compute_agent_address(signer.public_key())?,
+                    compute_org_address(&org_id)?,
+                ];
+                (addresses.clone(), addresses)
+            }
+        };
+
+        let payload_bytes = payload.into_bytes().map_err(|err| {
+            SabrePayloadBuildError::ProtoConversionError(format!(
+                "failed to serialize SabrePayload as bytes: {}",
+                err
+            ))
+        })?;
+
+        Ok(TransactionBuilder::new()
+            .with_family_name("sabre".into())
+            .with_family_version(env!("CARGO_PKG_VERSION").into())
+            .with_inputs(input_addresses)
+            .with_outputs(output_addresses)
+            .with_payload_hash_method(HashMethod::SHA512)
+            .with_payload(payload_bytes))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use transact::signing::hash::HashSigner;
 
     #[test]
     // check that a create contract action is built correctly
@@ -2679,5 +2838,335 @@ mod tests {
 
         let payload = SabrePayload::from_bytes(&bytes).unwrap();
         assert_eq!(payload, original);
+    }
+
+    #[test]
+    // check that a create contract can be converted -> sabre payload builder -> transaction
+    // builder -> transaction
+    fn create_contract_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = CreateContractActionBuilder::new()
+            .with_name("TestContract".to_string())
+            .with_version("0.1".to_string())
+            .with_inputs(vec!["test".to_string(), "input".to_string()])
+            .with_outputs(vec!["test".to_string(), "output".to_string()])
+            .with_contract(b"test".to_vec())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a delete contract can be converted -> sabre payload builder -> transaction
+    // builder -> transaction
+    fn delete_contract_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = DeleteContractActionBuilder::new()
+            .with_name("TestContract".to_string())
+            .with_version("0.1".to_string())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that an execute contract can be converted -> sabre payload builder -> transaction
+    // builder -> transaction
+    fn execute_contract_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = ExecuteContractActionBuilder::new()
+            .with_name("TestContract".to_string())
+            .with_version("0.1".to_string())
+            .with_inputs(vec!["abcdef".to_string(), "012345".to_string()])
+            .with_outputs(vec!["abcdef".to_string(), "678910".to_string()])
+            .with_payload(b"test_payload".to_vec())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a create contract registry can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn create_contract_registry_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = CreateContractRegistryActionBuilder::new()
+            .with_name("TestContract".to_string())
+            .with_owners(vec!["test".to_string(), "owner".to_string()])
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a delete contract registry can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn delete_contract_registry_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = DeleteContractRegistryActionBuilder::new()
+            .with_name("TestContract".to_string())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that an update contract registry owners can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn update_contract_registry_owners_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = UpdateContractRegistryOwnersActionBuilder::new()
+            .with_name("TestContract".to_string())
+            .with_owners(vec!["test".to_string(), "owner".to_string()])
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a create namespace registry can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn create_namespace_registry_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = CreateNamespaceRegistryActionBuilder::new()
+            .with_namespace("TestNamespace".to_string())
+            .with_owners(vec!["test".to_string(), "owner".to_string()])
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a delete namespace registry can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn delete_namespace_registry_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = DeleteNamespaceRegistryActionBuilder::new()
+            .with_namespace("TestNamespace".to_string())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a update namespace registry owners can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn update_namespace_registry_owners_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = UpdateNamespaceRegistryOwnersActionBuilder::new()
+            .with_namespace("TestNamespace".to_string())
+            .with_owners(vec!["test".to_string(), "owner".to_string()])
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a create namespace registry permission can be converted -> sabre payload builder
+    // -> transaction builder -> transaction
+    fn create_namespace_registry_permission_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = CreateNamespaceRegistryPermissionActionBuilder::new()
+            .with_namespace("TestNamespace".to_string())
+            .with_contract_name("TestContract".to_string())
+            .with_read(true)
+            .with_write(true)
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a delete namespace registry permission can be converted -> sabre payload builder
+    // -> transaction builder -> transaction
+    fn delete_namespace_registry_permission_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = DeleteNamespaceRegistryPermissionActionBuilder::new()
+            .with_namespace("TestNamespace".to_string())
+            .with_contract_name("TestContract".to_string())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a create smart permission can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn create_smart_permission_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = CreateSmartPermissionActionBuilder::new()
+            .with_name("SmartPermission".to_string())
+            .with_org_id("org_id".to_string())
+            .with_function(b"test".to_vec())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a update smart permission can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn update_smart_permission_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = UpdateSmartPermissionActionBuilder::new()
+            .with_name("SmartPermission".to_string())
+            .with_org_id("org_id".to_string())
+            .with_function(b"test".to_vec())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+    }
+
+    #[test]
+    // check that a delete smart permission can be converted -> sabre payload builder ->
+    // transaction builder -> transaction
+    fn delete_smart_permission_into_transaction() {
+        let signer = HashSigner::default();
+
+        let txn_pair = DeleteSmartPermissionActionBuilder::new()
+            .with_name("SmartPermission".to_string())
+            .with_org_id("org_id".to_string())
+            .into_payload_builder()
+            .expect("failed to convert to payload builder")
+            .into_transaction_builder(&signer)
+            .expect("failed to convert to transaction builder")
+            .build_pair(&signer)
+            .expect("failed to build transaction pair");
+
+        let txn_header = txn_pair.header();
+
+        assert_eq!(txn_header.family_name(), "sabre");
+        assert_eq!(txn_header.family_version(), env!("CARGO_PKG_VERSION"));
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
     }
 }


### PR DESCRIPTION
Add the `into_transaction_builder` method to the `SabrePayloadBuilder`
to support converting directly from a Sabre payload builder into
Transact's transaction builder.

Signed-off-by: Logan Seeley <seeley@bitwise.io>