### PR TITLE
Add headers to retired maintainers table

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,4 +13,6 @@
 | Shawn Amundson | vaporos | amundson |
 
 ### Retired Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
 | Adam Ludvik | aludvik | adamludvik |


### PR DESCRIPTION
Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>