### PR TITLE
Update protoc-rust to version 2.14

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -33,5 +33,5 @@ sha2 = "0.8"
 transact = "0.2"
 
 [build-dependencies]
-protoc-rust = "2"
+protoc-rust = "2.14"
 glob = "0.2"

--- a/sdks/rust/build.rs
+++ b/sdks/rust/build.rs
@@ -56,16 +56,18 @@ fn main() {
         .write_all(mod_file_content.as_bytes())
         .expect("Unable to write mod file");
 
-    protoc_rust::run(protoc_rust::Args {
-        out_dir: &dest_path.to_str().expect("Invalid proto destination path"),
-        input: &proto_src_files
-            .iter()
-            .map(|a| a.as_ref())
-            .collect::<Vec<&str>>(),
-        includes: &["src", "protos"],
-        customize: Customize::default(),
-    })
-    .expect("unable to run protoc");
+    protoc_rust::Codegen::new()
+        .out_dir(&dest_path.to_str().expect("Invalid proto destination path"))
+        .inputs(
+            &proto_src_files
+                .iter()
+                .map(|a| a.as_ref())
+                .collect::<Vec<&str>>(),
+        )
+        .includes(&["src", "protos"])
+        .customize(Customize::default())
+        .run()
+        .expect("unable to run protoc");
 }
 
 fn glob_simple(pattern: &str) -> Vec<String> {


### PR DESCRIPTION
protoc-rust::run is deprecated in 2.14. This commit updates
the build.rs files to use protoc-rust::Codegen instead.

The version requirement for protoc-rust has also been raised
from 2 to 2.14.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>