### PR TITLE
Remove redundant clones to fix Rust 1.44.0 clippy errors

### DIFF
--- a/sdks/rust/src/protocol/pike/state.rs
+++ b/sdks/rust/src/protocol/pike/state.rs
@@ -199,7 +199,7 @@ impl FromNative<Agent> for protos::pike_state::Agent {
 
         agent_proto.set_org_id(agent.org_id().to_string());
         agent_proto.set_public_key(agent.public_key().to_string());
-        agent_proto.set_active(agent.active().clone());
+        agent_proto.set_active(*agent.active());
         agent_proto.set_org_id(agent.org_id().to_string());
         agent_proto.set_roles(RepeatedField::from_vec(agent.roles().to_vec()));
         agent_proto.set_metadata(RepeatedField::from_vec(

--- a/tp/src/state.rs
+++ b/tp/src/state.rs
@@ -445,7 +445,7 @@ impl<'a> SabreState<'a> {
 
     pub fn delete_smart_permission(&mut self, org_id: &str, name: &str) -> Result<(), ApplyError> {
         let address = compute_smart_permission_address(org_id, name);
-        let d = self.context.delete_state_entry(&address.clone())?;
+        let d = self.context.delete_state_entry(&address)?;
         let deleted = match d {
             Some(deleted) => deleted,
             None => {


### PR DESCRIPTION
Signed-off-by: Andrea Gunderson <agunde@bitwise.io>