### PR TITLE
Replace Result.and_then(|x| Ok(y)) with map(|x| y) in load_signing_key

### DIFF
--- a/cli/src/key.rs
+++ b/cli/src/key.rs
@@ -72,11 +72,11 @@ fn load_signing_key(name: Option<&str>) -> Result<Secp256k1PrivateKey, CliError>
                 "Could not load signing key: unable to determine home directory",
             ))
         })
-        .and_then(|mut p| {
+        .map(|mut p| {
             p.push(".sawtooth");
             p.push("keys");
             p.push(format!("{}.priv", &username));
-            Ok(p)
+            p
         })?;
 
     if !private_key_filename.as_path().exists() {

--- a/example/intkey_multiply/cli/src/key.rs
+++ b/example/intkey_multiply/cli/src/key.rs
@@ -63,11 +63,11 @@ pub fn load_signing_key(name: Option<&str>) -> Result<Secp256k1PrivateKey, CliEr
                 "Could not load signing key: unable to determine home directory",
             ))
         })
-        .and_then(|mut p| {
+        .map(|mut p| {
             p.push(".sawtooth");
             p.push("keys");
             p.push(format!("{}.priv", &username));
-            Ok(p)
+            p
         })?;
 
     if !private_key_filename.as_path().exists() {


### PR DESCRIPTION
Signed-off-by: Andrea Gunderson <agunde@bitwise.io>