### PR TITLE
Update Sabre for new Transact Release

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,12 +10,12 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
+cylinder = "0.1"
 dirs = "2"
 futures = "0.1"
 hyper = "0.11"
 protobuf = "2"
 rust-crypto = "0.2"
-sawtooth-sdk = { version = "0.4", features = ["transact-compat"] }
 tokio-core = "0.1"
 users = "0.6"
 yaml-rust = "0.4"
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 sabre-sdk = {path = "../sdks/rust"}
-transact = "0.2"
+transact = "0.3"
 
 [build-dependencies]
 protoc-rust = "2"

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -16,7 +16,6 @@ use std::borrow::Borrow;
 use std::error::Error as StdError;
 
 use sabre_sdk::protocol::payload::{ActionBuildError, SabrePayloadBuildError};
-use sawtooth_sdk::signing;
 use transact::{
     protocol::{batch::BatchBuildError, transaction::TransactionBuildError},
     protos::ProtoConversionError,
@@ -28,7 +27,7 @@ pub enum CliError {
     /// is appropriate for display to the user without additional context
     UserError(String),
     IoError(std::io::Error),
-    SigningError(signing::Error),
+    SigningError(String),
     HyperError(hyper::Error),
     ProtocolBuildError(Box<dyn StdError>),
     ProtoConversionError(ProtoConversionError),
@@ -39,7 +38,7 @@ impl StdError for CliError {
         match self {
             CliError::UserError(_) => None,
             CliError::IoError(err) => Some(err),
-            CliError::SigningError(err) => Some(err),
+            CliError::SigningError(_) => None,
             CliError::HyperError(err) => Some(err),
             CliError::ProtocolBuildError(ref err) => Some(err.borrow()),
             CliError::ProtoConversionError(err) => Some(err),
@@ -52,7 +51,7 @@ impl std::fmt::Display for CliError {
         match *self {
             CliError::UserError(ref s) => write!(f, "Error: {}", s),
             CliError::IoError(ref err) => write!(f, "IoError: {}", err),
-            CliError::SigningError(ref err) => write!(f, "SigningError: {}", err),
+            CliError::SigningError(ref msg) => write!(f, "SigningError: {}", msg),
             CliError::HyperError(ref err) => write!(f, "HyperError: {}", err),
             CliError::ProtocolBuildError(ref err) => write!(f, "Protocol Error: {}", err),
             CliError::ProtoConversionError(ref err) => write!(f, "Proto Conversion Error: {}", err),
@@ -63,12 +62,6 @@ impl std::fmt::Display for CliError {
 impl From<std::io::Error> for CliError {
     fn from(e: std::io::Error) -> Self {
         CliError::IoError(e)
-    }
-}
-
-impl From<signing::Error> for CliError {
-    fn from(e: signing::Error) -> Self {
-        CliError::SigningError(e)
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -237,9 +237,9 @@ fn execute(exec_matches: &clap::ArgMatches) -> Result<(String, u64), CliError> {
         .with_outputs(outputs)
         .with_payload(contract_payload)
         .into_payload_builder()?
-        .into_transaction_builder(&signer)?
-        .into_batch_builder(&signer)?
-        .build(&signer)?;
+        .into_transaction_builder(&*signer)?
+        .into_batch_builder(&*signer)?
+        .build(&*signer)?;
 
     let batch_link = submit_batches(&url, vec![batch])?;
 
@@ -278,9 +278,9 @@ fn namespace_registry(ns_matches: &clap::ArgMatches) -> Result<(String, u64), Cl
             .with_namespace(namespace.into())
             .with_owners(owners)
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     } else if ns_matches.is_present("delete") {
@@ -293,9 +293,9 @@ fn namespace_registry(ns_matches: &clap::ArgMatches) -> Result<(String, u64), Cl
         let batch = DeleteNamespaceRegistryActionBuilder::new()
             .with_namespace(namespace.into())
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     } else {
@@ -307,9 +307,9 @@ fn namespace_registry(ns_matches: &clap::ArgMatches) -> Result<(String, u64), Cl
             .with_namespace(namespace.into())
             .with_owners(owners)
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     };
@@ -339,9 +339,9 @@ fn namespace_permission(perm_matches: &clap::ArgMatches) -> Result<(String, u64)
         let batch = DeleteNamespaceRegistryPermissionActionBuilder::new()
             .with_namespace(namespace.into())
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     } else {
@@ -358,9 +358,9 @@ fn namespace_permission(perm_matches: &clap::ArgMatches) -> Result<(String, u64)
             .with_read(read)
             .with_write(write)
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     };
@@ -394,9 +394,9 @@ fn contract_registry(cr_matches: &clap::ArgMatches) -> Result<(String, u64), Cli
             .with_name(name.into())
             .with_owners(owners)
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     } else if cr_matches.is_present("delete") {
@@ -409,9 +409,9 @@ fn contract_registry(cr_matches: &clap::ArgMatches) -> Result<(String, u64), Cli
         let batch = DeleteContractRegistryActionBuilder::new()
             .with_name(name.into())
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     } else {
@@ -423,9 +423,9 @@ fn contract_registry(cr_matches: &clap::ArgMatches) -> Result<(String, u64), Cli
             .with_name(name.into())
             .with_owners(owners)
             .into_payload_builder()?
-            .into_transaction_builder(&signer)?
-            .into_batch_builder(&signer)?
-            .build(&signer)?;
+            .into_transaction_builder(&*signer)?
+            .into_batch_builder(&*signer)?
+            .build(&*signer)?;
 
         submit_batches(&url, vec![batch])?
     };
@@ -460,9 +460,9 @@ fn smart_permission(sp_matches: &clap::ArgMatches) -> Result<(String, u64), CliE
                 .with_org_id(org_id.into())
                 .with_function(function)
                 .into_payload_builder()?
-                .into_transaction_builder(&signer)?
-                .into_batch_builder(&signer)?
-                .build(&signer)?;
+                .into_transaction_builder(&*signer)?
+                .into_batch_builder(&*signer)?
+                .build(&*signer)?;
 
             submit_batches(&url, vec![batch])?
         }
@@ -480,9 +480,9 @@ fn smart_permission(sp_matches: &clap::ArgMatches) -> Result<(String, u64), CliE
                 .with_org_id(org_id.to_string())
                 .with_function(function)
                 .into_payload_builder()?
-                .into_transaction_builder(&signer)?
-                .into_batch_builder(&signer)?
-                .build(&signer)?;
+                .into_transaction_builder(&*signer)?
+                .into_batch_builder(&*signer)?
+                .build(&*signer)?;
 
             submit_batches(&url, vec![batch])?
         }
@@ -496,9 +496,9 @@ fn smart_permission(sp_matches: &clap::ArgMatches) -> Result<(String, u64), CliE
                 .with_name(name.to_string())
                 .with_org_id(org_id.to_string())
                 .into_payload_builder()?
-                .into_transaction_builder(&signer)?
-                .into_batch_builder(&signer)?
-                .build(&signer)?;
+                .into_transaction_builder(&*signer)?
+                .into_batch_builder(&*signer)?
+                .build(&*signer)?;
 
             submit_batches(&url, vec![batch])?
         }

--- a/cli/src/upload.rs
+++ b/cli/src/upload.rs
@@ -59,9 +59,9 @@ pub fn do_upload(
         .with_outputs(definition.outputs)
         .with_contract(contract)
         .into_payload_builder()?
-        .into_transaction_builder(&signer)?
-        .into_batch_builder(&signer)?
-        .build(&signer)?;
+        .into_transaction_builder(&*signer)?
+        .into_batch_builder(&*signer)?
+        .build(&*signer)?;
 
     submit_batches(url, vec![batch])
 }

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -30,7 +30,8 @@ protobuf = "2"
 sha2 = "0.8"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-transact = "0.2"
+transact = "0.3"
+cylinder = "0.1"
 
 [build-dependencies]
 protoc-rust = "2.14"

--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -33,7 +33,7 @@ name = "sawtooth-sabre"
 path = "src/main.rs"
 
 [dependencies]
-sawtooth-sdk = "0.4"
+sawtooth-sdk = "0.5"
 sabre-sdk = {path = "../sdks/rust"}
 log = "0.4"
 simple_logger = "1"

--- a/tp/src/main.rs
+++ b/tp/src/main.rs
@@ -15,7 +15,7 @@
 #[macro_use]
 extern crate clap;
 
-use log::Level;
+use log::LevelFilter;
 
 use sawtooth_sabre::handler::SabreTransactionHandler;
 use sawtooth_sdk::processor::TransactionProcessor;
@@ -29,15 +29,15 @@ fn main() {
         (@arg verbose: -v --verbose +multiple
          "increase output verbosity"))
     .get_matches();
-
+    let logger = simple_logger::SimpleLogger::new();
     let logger = match matches.occurrences_of("verbose") {
-        0 => simple_logger::init_with_level(Level::Warn),
-        1 => simple_logger::init_with_level(Level::Info),
-        2 => simple_logger::init_with_level(Level::Debug),
-        _ => simple_logger::init_with_level(Level::Trace),
+        0 => logger.with_level(LevelFilter::Warn),
+        1 => logger.with_level(LevelFilter::Info),
+        2 => logger.with_level(LevelFilter::Debug),
+        _ => logger.with_level(LevelFilter::Trace),
     };
 
-    logger.expect("Failed to create logger");
+    logger.init().expect("Failed to create logger");
 
     let connect = matches
         .value_of("connect")


### PR DESCRIPTION
Requires pulling in cylinder for signing.

Also updates simple_logger usage to remove deprecation warnings. 