### PR TITLE
Add release notes for Sabre 0.6.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Changes in Sawtooth Sabre 0.6.0
+
+* Add `add_events` to Sabre TransactionContext which adds events to  the
+  execution result for a transaction. This brings the Sabre API closer to the
+  Sawtooth TransactionContext API.
+* Improve error messages when there is an InvalidTransaction caused by a
+  transaction not being submitted by an authorized admin.
+* Update sawtooth-sdk dependency version to 0.5.
+* Update transact dependency version to 0.3.
+
 ## Changes in Sawtooth Sabre 0.5.2
 
 * Add `Result` class to the AssemblyScript SDK for basic error handling

--- a/docs/source/version_compatibility.rst
+++ b/docs/source/version_compatibility.rst
@@ -55,3 +55,13 @@ the Sabre transaction processor image.
 |            |          |           |         |   `into_payload_builder` method|
 |            |          |           |         |   to all `*ActionBuilders`.    |
 +------------+----------+-----------+---------+--------------------------------+
+| 0.6        | 0.6      | 0.6       |  0.5    | - Update sawtooth-sdk version  |
+|            |          |           |         | to 0.5.                        |
+|            |          |           |         | - Updates transact version to  |
+|            |          |           |         | 0.3.                           |
+|            |          |           |         | - Updates TransactionBuilder   |
+|            |          |           |         | to take cylinder `Signer`      |
+|            |          |           |         | instead of transact `Signer`   |
+|            |          |           |         | which was removed in the new   |
+|            |          |           |         | transact version.              |
++------------+----------+-----------+---------+--------------------------------+

--- a/sdks/rust/src/protocol/mod.rs
+++ b/sdks/rust/src/protocol/mod.rs
@@ -20,7 +20,7 @@ use std::error::Error;
 
 use sha2::{Digest, Sha512};
 
-pub const SABRE_PROTOCOL_VERSION: &str = "0.5";
+pub const SABRE_PROTOCOL_VERSION: &str = "0.6";
 
 pub const ADMINISTRATORS_SETTING_KEY: &str = "sawtooth.swa.administrators";
 


### PR DESCRIPTION
Also adds version compatibility and update SABRE_PROTOCOL_VERSION