### PR TITLE
Remove no_mangle from sabre externs

### DIFF
--- a/sdks/rust/src/externs.rs
+++ b/sdks/rust/src/externs.rs
@@ -15,7 +15,6 @@
 pub type WasmPtr = i32;
 pub type WasmPtrList = i32;
 
-#[no_mangle]
 extern "C" {
     pub fn get_state(addresses: WasmPtrList) -> WasmPtrList;
     pub fn set_state(addr_data: WasmPtrList) -> i32;


### PR DESCRIPTION
attribute no_mangle should be applied to a function or static
this was previously accepted by the compiler but is being
phased out; it will become a hard error in a future release

Since, no_mangle was on extern functions, it should not be
required.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>