### PR TITLE
Update the sabre family version to 1

### DIFF
--- a/sdks/rust/src/protocol/mod.rs
+++ b/sdks/rust/src/protocol/mod.rs
@@ -20,7 +20,7 @@ use std::error::Error;
 
 use sha2::{Digest, Sha512};
 
-pub const SABRE_PROTOCOL_VERSION: &str = "0.6";
+pub const SABRE_PROTOCOL_VERSION: &str = "1";
 
 pub const ADMINISTRATORS_SETTING_KEY: &str = "sawtooth.swa.administrators";
 

--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -68,7 +68,7 @@ impl SabreTransactionHandler {
     pub fn new() -> SabreTransactionHandler {
         SabreTransactionHandler {
             family_name: "sabre".into(),
-            family_versions: vec![SABRE_PROTOCOL_VERSION.into()],
+            family_versions: vec!["0.5".into(), "0.6".into(), SABRE_PROTOCOL_VERSION.into()],
             namespaces: vec![
                 NAMESPACE_REGISTRY_PREFIX.into(),
                 CONTRACT_REGISTRY_PREFIX.into(),


### PR DESCRIPTION
The family version about the protocol of the smart contracts and
not about the version of Sabre as a whole. Setting the family
version to 1 will help remove this confusion.

0.5 and 0.6 have also been included in the family version list
so that sabre can support older client versions that are
still compatible.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>