### PR TITLE
Update allowed family version to include 0.6 and 1

### DIFF
--- a/tp/src/handler.rs
+++ b/tp/src/handler.rs
@@ -68,7 +68,7 @@ impl SabreTransactionHandler {
     pub fn new() -> SabreTransactionHandler {
         SabreTransactionHandler {
             family_name: "sabre".into(),
-            family_versions: vec![SABRE_PROTOCOL_VERSION.into()],
+            family_versions: vec![SABRE_PROTOCOL_VERSION.into(), "0.6".into(), "1".into()],
             namespaces: vec![
                 NAMESPACE_REGISTRY_PREFIX.into(),
                 CONTRACT_REGISTRY_PREFIX.into(),


### PR DESCRIPTION
This will allow 0.5 sabre to accept transactions from
0.6 and 1 versions of sabre.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>