### PR TITLE
Properly handle error returned from externs::get_ptr_len

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -738,7 +738,14 @@ impl From<WasmSdkError> for ApplyError {
 unsafe fn ptr_to_vec(ptr: WasmPtr) -> Result<Option<Vec<u8>>, WasmSdkError> {
     let mut vec = Vec::new();
 
-    for i in 0..externs::get_ptr_len(ptr) {
+    let ptr_len = externs::get_ptr_len(ptr);
+    if ptr_len == -1 {
+        return Err(WasmSdkError::MemoryRetrievalError(
+            "WasmPtr does not exist".to_string(),
+        ));
+    }
+
+    for i in 0..ptr_len {
         vec.push(externs::read_byte(ptr as isize + i));
     }
 


### PR DESCRIPTION
The ptr_to_vec to function was not properly checking
the return type of externs::get_ptr_len, which returns
a -1 if there is an error finding the ptr.

This issues was caught by the 1.50 clippy updates
clippy::unnecessary_wraps.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>