### PR TITLE
Break out checking if a signer is an admin into trait

### DIFF
--- a/tp/src/admin/allow_all.rs
+++ b/tp/src/admin/allow_all.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Cargill Incorporated
+// Copyright 2021 Cargill Incorporated
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-extern crate log;
+//! An implementations of `AdminPermission` that always returns true
 
-mod addressing;
-pub mod admin;
-pub mod handler;
-mod payload;
-mod state;
-mod wasm_executor;
+use sawtooth_sdk::processor::handler::ApplyError;
 
-pub use sabre_sdk::protocol::{ADMINISTRATORS_SETTING_ADDRESS, ADMINISTRATORS_SETTING_KEY};
+use crate::state::SabreState;
+
+use super::AdminPermission;
+
+#[derive(Default)]
+pub struct AllowAllAdminPermission;
+
+impl AdminPermission for AllowAllAdminPermission {
+    fn is_admin(&self, _signer: &str, _state: &mut SabreState) -> Result<bool, ApplyError> {
+        Ok(true)
+    }
+}

--- a/tp/src/admin/mod.rs
+++ b/tp/src/admin/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A trait used by the Sabre transaction handle for verifying if a signer is an admin
+//!
+//! Includes two implementations, `AllowAllAdminPermission` and `SettingsAdminPermission`.
+//! `SettingsAdminPermission` checks Sawtooth Settings for admin keys. The
+//! `AllowAllAdminPermission` will always return true.
+
+mod allow_all;
+mod settings;
+
+pub use self::allow_all::AllowAllAdminPermission;
+pub use self::settings::SettingsAdminPermission;
+use sawtooth_sdk::processor::handler::ApplyError;
+
+use crate::state::SabreState;
+
+/// Used to verify if a signer is an admin
+pub trait AdminPermission {
+    /// Returns if the signer is an admin
+    ///
+    /// # Arguments
+    ///
+    /// * `signer` - The public key of the transaction signer
+    /// * `state` - `SabreState` for fetching information about admins
+    fn is_admin(&self, signer: &str, state: &mut SabreState) -> Result<bool, ApplyError>;
+}

--- a/tp/src/admin/settings.rs
+++ b/tp/src/admin/settings.rs
@@ -1,0 +1,56 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An implementations of `AdminPermission` that checks Sawtooth Settings and returns true if the
+//! signer is listed as an admin.
+
+use sabre_sdk::protocol::ADMINISTRATORS_SETTING_KEY;
+use sawtooth_sdk::processor::handler::ApplyError;
+
+use super::AdminPermission;
+
+use crate::state::SabreState;
+
+#[derive(Default)]
+pub struct SettingsAdminPermission;
+
+impl AdminPermission for SettingsAdminPermission {
+    fn is_admin(&self, signer: &str, state: &mut SabreState) -> Result<bool, ApplyError> {
+        let setting = match state.get_admin_setting() {
+            Ok(Some(setting)) => setting,
+            Ok(None) => {
+                return Err(ApplyError::InvalidTransaction(format!(
+                    "Admins not set, cannot check signer permissions: {}",
+                    signer,
+                )));
+            }
+            Err(err) => {
+                return Err(ApplyError::InvalidTransaction(format!(
+                    "Unable to check state: {}",
+                    err,
+                )));
+            }
+        };
+
+        for entry in setting.get_entries() {
+            if entry.key == ADMINISTRATORS_SETTING_KEY {
+                let values = entry.value.split(',');
+                let value_vec: Vec<&str> = values.collect();
+                return Ok(value_vec.contains(&signer));
+            }
+        }
+
+        Ok(false)
+    }
+}


### PR DESCRIPTION
The AdminPermission trait will be used to decouple the Sabre Transaction Handler
from Sawtooth Settings when checking  if a signer is an
admin.

Two implementation are provided. One to still check Settings
and one no-op implementation that always returns true.

When starting up the transaction processor provide the flag `--admin-no-op` to treat all signers as admins. 