### PR TITLE
Fix question mark operator is useless here clippy error

### DIFF
--- a/cli/src/key.rs
+++ b/cli/src/key.rs
@@ -101,11 +101,11 @@ fn load_signing_key(name: Option<&str>) -> Result<PrivateKey, CliError> {
         }
     };
 
-    Ok(PrivateKey::new_from_hex(&key_str).map_err(|err| {
+    PrivateKey::new_from_hex(&key_str).map_err(|err| {
         CliError::SigningError(format!(
             "Unable to parse private key file {}: {} ",
             private_key_filename.display(),
             err
         ))
-    })?)
+    })
 }


### PR DESCRIPTION
The return type was needlessly wrapped in an Ok()
with a question mark to return if error. Instead
we can just return the value returned from
PrivateKey::new_from_hex.

This was caught by a clippy error in Rust 1.51.0

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>