### PR TITLE
Update all sawtooth-sdk dep to use the crate used by the tp

### DIFF
--- a/contracts/sawtooth-pike/api/Cargo.toml
+++ b/contracts/sawtooth-pike/api/Cargo.toml
@@ -25,7 +25,7 @@ serde = "1.0"
 serde_yaml = "0.7"
 serde_json = "1.0"
 serde_derive = "1.0"
-sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+sawtooth-sdk = "0.5"
 pike_db = { path = "../db/pike_db/" }
 protobuf = "2.19"
 uuid = { version = "0.5", features = ["v4"] }

--- a/contracts/sawtooth-pike/cli/Cargo.toml
+++ b/contracts/sawtooth-pike/cli/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["Cargill"]
 build = "build.rs"
 
 [dependencies]
-sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+sawtooth-sdk = "0.5"
 addresser = {path = "../addresser"}
 protobuf = "2.19"
 clap = "2"

--- a/contracts/sawtooth-pike/state_delta_export/Cargo.toml
+++ b/contracts/sawtooth-pike/state_delta_export/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["Cargill"]
 build = "build.rs"
 
 [dependencies]
-sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+sawtooth-sdk = "0.5"
 pike_db = { path = "../db/pike_db/" }
 addresser = { path = "../addresser/" }
 log = "0.3.8"

--- a/contracts/sawtooth-pike/tp/Cargo.toml
+++ b/contracts/sawtooth-pike/tp/Cargo.toml
@@ -29,7 +29,7 @@ rust-crypto-wasm = "0.3"
 sabre-sdk = {path = "../../../sdks/rust"}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+sawtooth-sdk = "0.5"
 log = "0.3.8"
 log4rs = "0.7.0"
 simple_logger = "0.4.0"

--- a/docs/source/application_developer_guide.rst
+++ b/docs/source/application_developer_guide.rst
@@ -119,7 +119,7 @@ The following is an example for intkey-multiply
 
   [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
   rust-crypto = "0.2.36"
-  sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+  sawtooth-sdk = "0.5"
   rustc-serialize = "0.3.22"
   log = "0.3.0"
   log4rs = "0.7.0"

--- a/example/intkey_multiply/cli/Cargo.toml
+++ b/example/intkey_multiply/cli/Cargo.toml
@@ -28,6 +28,6 @@ futures = "0.1"
 hyper = "0.11"
 rust-crypto = "0.2"
 protobuf = "2.19"
-sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+sawtooth-sdk = "0.5"
 tokio-core = "0.1"
 users = "0.6"

--- a/example/intkey_multiply/processor/Cargo.toml
+++ b/example/intkey_multiply/processor/Cargo.toml
@@ -29,7 +29,7 @@ sabre-sdk = {path = "../../../sdks/rust"}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rust-crypto = "0.2.36"
-sawtooth-sdk = {git = "https://github.com/hyperledger/sawtooth-sdk-rust"}
+sawtooth-sdk = "0.5"
 rustc-serialize = "0.3.22"
 log = "0.3.0"
 log4rs = "0.7.0"


### PR DESCRIPTION
Examples were still pulling in the sawtooth-sdk from github.
They should instead be using the published crate.

This will fix lint that was caused when the rust-sdk HEAD branch
was switched to main instead of master.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>