### PR TITLE
Add show/list subcommands to the sabre CLI 

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ name = "sabre"
 path = "src/main.rs"
 
 [dependencies]
+base64 = "0.13"
 clap = "2"
 cylinder = "0.2"
 dirs = "2"

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -16,9 +16,10 @@ use std::borrow::Borrow;
 use std::error::Error as StdError;
 
 use sabre_sdk::protocol::payload::{ActionBuildError, SabrePayloadBuildError};
+use sabre_sdk::protos::ProtoConversionError;
 use transact::{
     protocol::{batch::BatchBuildError, transaction::TransactionBuildError},
-    protos::ProtoConversionError,
+    protos::ProtoConversionError as TransactProtoConversionError,
 };
 
 #[derive(Debug)]
@@ -31,6 +32,7 @@ pub enum CliError {
     HyperError(hyper::Error),
     ProtocolBuildError(Box<dyn StdError>),
     ProtoConversionError(ProtoConversionError),
+    TransactProtoConversionError(TransactProtoConversionError),
 }
 
 impl StdError for CliError {
@@ -42,6 +44,7 @@ impl StdError for CliError {
             CliError::HyperError(err) => Some(err),
             CliError::ProtocolBuildError(ref err) => Some(err.borrow()),
             CliError::ProtoConversionError(err) => Some(err),
+            CliError::TransactProtoConversionError(err) => Some(err),
         }
     }
 }
@@ -55,6 +58,9 @@ impl std::fmt::Display for CliError {
             CliError::HyperError(ref err) => write!(f, "HyperError: {}", err),
             CliError::ProtocolBuildError(ref err) => write!(f, "Protocol Error: {}", err),
             CliError::ProtoConversionError(ref err) => write!(f, "Proto Conversion Error: {}", err),
+            CliError::TransactProtoConversionError(ref err) => {
+                write!(f, "Transact Proto Conversion Error: {}", err)
+            }
         }
     }
 }
@@ -74,6 +80,12 @@ impl From<hyper::Error> for CliError {
 impl From<ProtoConversionError> for CliError {
     fn from(e: ProtoConversionError) -> Self {
         CliError::ProtoConversionError(e)
+    }
+}
+
+impl From<TransactProtoConversionError> for CliError {
+    fn from(e: TransactProtoConversionError) -> Self {
+        CliError::TransactProtoConversionError(e)
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -51,6 +51,8 @@ use submit::submit_batches;
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+const DEFAULT_REST_API_ENDPOINT: &str = "http://localhost:8008/";
+
 fn run() -> Result<(), CliError> {
     // Below, unwrap() is used on required arguments, since they will always
     // contain a value (and lack of value is should cause a panic). unwrap()
@@ -229,7 +231,7 @@ fn upload(upload_matches: &clap::ArgMatches) -> Result<(String, u64), CliError> 
     let key_name = upload_matches.value_of("key");
     let url = upload_matches
         .value_of("url")
-        .unwrap_or("http://localhost:8008/");
+        .unwrap_or(DEFAULT_REST_API_ENDPOINT);
     let wasm_name = upload_matches.value_of("wasm");
 
     let wait = match value_t!(upload_matches, "wait", u64) {
@@ -250,7 +252,7 @@ fn execute(exec_matches: &clap::ArgMatches) -> Result<(String, u64), CliError> {
     let key_name = exec_matches.value_of("key");
     let url = exec_matches
         .value_of("url")
-        .unwrap_or("http://localhost:8008/");
+        .unwrap_or(DEFAULT_REST_API_ENDPOINT);
 
     let wait = match value_t!(exec_matches, "wait", u64) {
         Ok(wait) => wait,
@@ -309,7 +311,7 @@ fn namespace_registry(ns_matches: &clap::ArgMatches) -> Result<(String, u64), Cl
 
     let url = ns_matches
         .value_of("url")
-        .unwrap_or("http://localhost:8008/");
+        .unwrap_or(DEFAULT_REST_API_ENDPOINT);
 
     let wait = match value_t!(ns_matches, "wait", u64) {
         Ok(wait) => wait,
@@ -379,7 +381,7 @@ fn namespace_permission(perm_matches: &clap::ArgMatches) -> Result<(String, u64)
     let key_name = perm_matches.value_of("key");
     let url = perm_matches
         .value_of("url")
-        .unwrap_or("http://localhost:8008/");
+        .unwrap_or(DEFAULT_REST_API_ENDPOINT);
 
     let wait = match value_t!(perm_matches, "wait", u64) {
         Ok(wait) => wait,
@@ -431,7 +433,7 @@ fn contract_registry(cr_matches: &clap::ArgMatches) -> Result<(String, u64), Cli
 
     let url = cr_matches
         .value_of("url")
-        .unwrap_or("http://localhost:8008/");
+        .unwrap_or(DEFAULT_REST_API_ENDPOINT);
 
     let wait = value_t!(cr_matches, "wait", u64).unwrap_or(0);
 
@@ -491,7 +493,7 @@ fn contract_registry(cr_matches: &clap::ArgMatches) -> Result<(String, u64), Cli
 fn smart_permission(sp_matches: &clap::ArgMatches) -> Result<(String, u64), CliError> {
     let url = sp_matches
         .value_of("url")
-        .unwrap_or("http://localhost:8008/");
+        .unwrap_or(DEFAULT_REST_API_ENDPOINT);
 
     let wait = match value_t!(sp_matches, "wait", u64) {
         Ok(wait) => wait,
@@ -571,7 +573,7 @@ fn smart_permission(sp_matches: &clap::ArgMatches) -> Result<(String, u64), CliE
 fn contract(contract_matches: &clap::ArgMatches) -> Result<(), CliError> {
     match contract_matches.subcommand() {
         ("list", Some(matches)) => {
-            let url = matches.value_of("url").unwrap_or("http://localhost:8008/");
+            let url = matches.value_of("url").unwrap_or(DEFAULT_REST_API_ENDPOINT);
 
             let format = matches
                 .value_of("format")
@@ -623,7 +625,7 @@ fn contract(contract_matches: &clap::ArgMatches) -> Result<(), CliError> {
             Ok(())
         }
         ("show", Some(matches)) => {
-            let url = matches.value_of("url").unwrap_or("http://localhost:8008/");
+            let url = matches.value_of("url").unwrap_or(DEFAULT_REST_API_ENDPOINT);
 
             let contract = matches
                 .value_of("contract")

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -1,0 +1,72 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains functions which assist with fetching state
+
+use futures::Stream;
+use futures::{future, Future};
+use hyper::client::{Client, Request};
+use hyper::Method;
+use std::str;
+
+use crate::error::CliError;
+
+pub fn get_state_with_prefix(url: &str, prefix: &str) -> Result<Vec<StateEntry>, CliError> {
+    let post_url = String::from(url) + "/state?address=" + prefix;
+    let hyper_uri = match post_url.parse::<hyper::Uri>() {
+        Ok(uri) => uri,
+        Err(e) => return Err(CliError::UserError(format!("Invalid URL: {}: {}", e, url))),
+    };
+
+    match hyper_uri.scheme() {
+        Some(scheme) => {
+            if scheme != "http" {
+                return Err(CliError::UserError(format!(
+                    "Unsupported scheme ({}) in URL: {}",
+                    scheme, url
+                )));
+            }
+        }
+        None => {
+            return Err(CliError::UserError(format!("No scheme in URL: {}", url)));
+        }
+    }
+
+    let mut core = tokio_core::reactor::Core::new()?;
+    let handle = core.handle();
+    let client = Client::configure().build(&handle);
+
+    let req = Request::new(Method::Get, hyper_uri);
+
+    let work = client.request(req).and_then(|res| {
+        res.body().concat2().and_then(move |chunks| {
+            future::ok(serde_json::from_slice::<JsonStateEntry>(&chunks).unwrap())
+        })
+    });
+
+    let response = core.run(work)?;
+
+    Ok(response.data)
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonStateEntry {
+    data: Vec<StateEntry>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct StateEntry {
+    pub address: String,
+    pub data: String,
+}


### PR DESCRIPTION
The following command (with output) have been added to the sabre CLI

```
sabre contract list -h
sabre-contract-list 
List all registered Sabre smart contracts

USAGE:
    sabre contract list [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -f, --format <format>    Format to display list of smart contracts in [default: human]  [possible values: human,
                             csv]
    -U, --url <url>          URL to the Sawtooth REST API
```

```
sabre contract list

NAME            VERSIONS OWNERS                                                             
intkey_multiply 1.0      03e0c781880ec8632ed5eb49f5613c69f6bfd67d76a2919efca1c58260fd313424 
1cf126                   test  
```

```
sabre contract show  -h
sabre-contract-show 
Show details about a registered Sabre smart contract

USAGE:
    sabre contract show [OPTIONS] <contract>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -U, --url <url>    URL to the scabbard REST API

ARGS:
    <contract>    Name and version of the smart contract in the form 'name:version'
```

```
sabre contract show intkey_multiply:1.0  

intkey_multiply 1.0
  inputs:
  - cad11d
  - 1cf126
  - 00ec03
  outputs:
  - 1cf126
  - cad11d
  - 00ec03
  creator: 03e0c781880ec8632ed5eb49f5613c69f6bfd67d76a2919efca1c58260fd313424
```