### PR TITLE
Make AdminPermission trait Send

### DIFF
--- a/tp/src/admin/mod.rs
+++ b/tp/src/admin/mod.rs
@@ -28,7 +28,7 @@ use sawtooth_sdk::processor::handler::ApplyError;
 use crate::state::SabreState;
 
 /// Used to verify if a signer is an admin
-pub trait AdminPermission {
+pub trait AdminPermission: Send {
     /// Returns if the signer is an admin
     ///
     /// # Arguments


### PR DESCRIPTION
Newer versions of scabbard require that the trait be Send.

Signed-off-by: Caleb Hill <hill@bitwise.io>