### PR TITLE
Update wasmi version

### DIFF
--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -40,7 +40,7 @@ simple_logger = "1"
 clap = "2"
 protobuf = "2.19"
 rust-crypto = "0.2.36"
-wasmi = "0.4"
+wasmi = "0.9"
 
 [build-dependencies]
 protoc-rust = "2"


### PR DESCRIPTION
Update the version of the wasmi library from 0.4 to 0.9 to minimize memory footprint. Changes between versions 0.4 and 0.9 of wasmi fixed an issue where unnecessarily large amounts of memory were being allocated.