### PR TITLE
Remove known errors during .deb package install

### DIFF
--- a/cli/Dockerfile-installed-bionic
+++ b/cli/Dockerfile-installed-bionic
@@ -59,7 +59,7 @@ FROM hyperledger/sawtooth-shell:nightly
 COPY --from=sabre-cli-builder /project/cli/target/debian/sabre-cli*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/sabre-cli_*.deb || true \
+ && dpkg --unpack /tmp/sabre-cli_*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/cli/Dockerfile-installed-xenial
+++ b/cli/Dockerfile-installed-xenial
@@ -56,7 +56,7 @@ FROM hyperledger/sawtooth-all:1.0
 COPY --from=sabre-cli-builder /project/cli/target/debian/sabre-cli*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/sabre-cli_*.deb || true \
+ && dpkg --unpack /tmp/sabre-cli_*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/api/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/api/Dockerfile-installed-bionic
@@ -57,7 +57,7 @@ FROM ubuntu:bionic
 COPY --from=pike-api-builder /project/contracts/sawtooth-pike/api/target/debian/pike-api*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/pike-api*.deb || true \
+ && dpkg --unpack /tmp/pike-api*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/api/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/api/Dockerfile-installed-xenial
@@ -57,7 +57,7 @@ FROM ubuntu:xenial
 COPY --from=pike-api-builder /project/contracts/sawtooth-pike/api/target/debian/pike-api*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/pike-api*.deb || true \
+ && dpkg --unpack /tmp/pike-api*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/cli/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/cli/Dockerfile-installed-bionic
@@ -64,7 +64,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
  && apt-get -f -y install \
     python3-sawtooth-cli \
     python3-sawtooth-sdk \
- && dpkg -i /tmp/pike-cli*.deb || true \
+ && dpkg --unpack  /tmp/pike-cli*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/cli/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/cli/Dockerfile-installed-xenial
@@ -61,6 +61,6 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial univers
  && apt-get -f -y install \
     python3-sawtooth-cli \
     python3-sawtooth-sdk \
- && dpkg -i /tmp/pike-cli*.deb || true
+ && dpkg --unpack  /tmp/pike-cli*.deb
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-bionic
@@ -56,7 +56,7 @@ FROM ubuntu:bionic
 COPY --from=pike-sde-builder /project/contracts/sawtooth-pike/state_delta_export/target/debian/pike-sde*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/pike-sde*.deb || true \
+ && dpkg --unpack /tmp/pike-sde*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/state_delta_export/Dockerfile-installed-xenial
@@ -56,7 +56,7 @@ FROM ubuntu:xenial
 COPY --from=pike-sde-builder /project/contracts/sawtooth-pike/state_delta_export/target/debian/pike-sde*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/pike-sde*.deb || true \
+ && dpkg --unpack /tmp/pike-sde*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/tp/Dockerfile-installed-bionic
+++ b/contracts/sawtooth-pike/tp/Dockerfile-installed-bionic
@@ -55,7 +55,7 @@ FROM ubuntu:bionic
 COPY --from=pike-tp-builder /project/contracts/sawtooth-pike/tp/target/debian/pike*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/pike*.deb || true \
+ && dpkg --unpack /tmp/pike*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/contracts/sawtooth-pike/tp/Dockerfile-installed-xenial
+++ b/contracts/sawtooth-pike/tp/Dockerfile-installed-xenial
@@ -55,7 +55,7 @@ FROM ubuntu:xenial
 COPY --from=pike-tp-builder /project/contracts/sawtooth-pike/tp/target/debian/pike*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/pike*.deb || true \
+ && dpkg --unpack /tmp/pike*.deb \
  && apt-get -f -y install
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/tp/Dockerfile-installed-bionic
+++ b/tp/Dockerfile-installed-bionic
@@ -59,5 +59,5 @@ FROM ubuntu:bionic
 COPY --from=sabre-tp-builder /project/tp/target/debian/sawtooth-sabre_*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/sawtooth-sabre_*.deb || true \
+ && dpkg --unpack /tmp/sawtooth-sabre_*.deb \
  && apt-get -f -y install

--- a/tp/Dockerfile-installed-xenial
+++ b/tp/Dockerfile-installed-xenial
@@ -56,5 +56,5 @@ FROM ubuntu:xenial
 COPY --from=sabre-tp-builder /project/tp/target/debian/sawtooth-sabre_*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/sawtooth-sabre_*.deb || true \
+ && dpkg --unpack /tmp/sawtooth-sabre_*.deb \
  && apt-get -f -y install


### PR DESCRIPTION
Switching from "-i" to "--unpack" gets rid of the caught missing
dependency errors while installing built .deb packages.

Displaying these errors, though caught, could be confusing to new
users of the project.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>