### PR TITLE
Rename GHA workflow files

### DIFF
--- a/.github/workflows/0-7-build-docker.yaml
+++ b/.github/workflows/0-7-build-docker.yaml
@@ -1,4 +1,4 @@
-name: Unit Test Sabre
+name: 0-7 Build Docker Images
 
 on:
   pull_request:
@@ -11,10 +11,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit_test_sabre:
+  build_docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Display envvars
         run: env
@@ -22,5 +24,5 @@ jobs:
       - name: Install Just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
-      - name: Unit Test Sabre
-        run: just ci-test
+      - name: Build Docker Images
+        run: just docker-build

--- a/.github/workflows/0-7-build-docs.yaml
+++ b/.github/workflows/0-7-build-docs.yaml
@@ -1,4 +1,4 @@
-name: Build Docs
+name: 0-7 Build Docs
 
 on:
   pull_request:

--- a/.github/workflows/0-7-integration-tests.yaml
+++ b/.github/workflows/0-7-integration-tests.yaml
@@ -1,4 +1,4 @@
-name: Build Docker Images
+name: 0-7 Run Integration Tests
 
 on:
   pull_request:
@@ -11,12 +11,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_docker:
+  integration_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Display envvars
         run: env
@@ -24,5 +22,5 @@ jobs:
       - name: Install Just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
-      - name: Build Docker Images
-        run: just docker-build
+      - name: Run Integration Tests
+        run: just integration-test

--- a/.github/workflows/0-7-lint-sabre.yaml
+++ b/.github/workflows/0-7-lint-sabre.yaml
@@ -1,4 +1,4 @@
-name: Run Integration Tests
+name: 0-7 Lint Sabre
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  integration_tests:
+  lint_sabre:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,5 +22,5 @@ jobs:
       - name: Install Just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
-      - name: Run Integration Tests
-        run: just integration-test
+      - name: Run Lint/Clippy on Sabre
+        run: just ci-lint

--- a/.github/workflows/0-7-merge.yaml
+++ b/.github/workflows/0-7-merge.yaml
@@ -1,9 +1,9 @@
-name: Merge
+name: 0-7 Merge
 
 on:
   push:
-  schedule:
-    - cron: "0 7 * * *"
+    branches:
+      - 0-7
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/0-7-unit-test-sabre.yaml
+++ b/.github/workflows/0-7-unit-test-sabre.yaml
@@ -1,4 +1,4 @@
-name: Lint Sabre
+name: 0-7 Unit Test Sabre
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint_sabre:
+  unit_test_sabre:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,5 +22,5 @@ jobs:
       - name: Install Just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
-      - name: Run Lint/Clippy on Sabre
-        run: just ci-lint
+      - name: Unit Test Sabre
+        run: just ci-test


### PR DESCRIPTION
If workflows share the name filename as an existing workflow in the main
branch, github will execute the workflow from main instead of the branch
appropriate instance.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>