### PR TITLE
Update Transact dependency to 0.4

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 sabre-sdk = {path = "../sdks/rust"}
-transact = "0.3"
+transact = "0.4"
 
 [build-dependencies]
 protoc-rust = "2"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -30,7 +30,7 @@ protobuf = "2.19"
 sha2 = "0.8"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-transact = "0.3"
+transact = "0.4"
 cylinder = "0.2"
 
 [build-dependencies]

--- a/sdks/rust/src/protocol/payload.rs
+++ b/sdks/rust/src/protocol/payload.rs
@@ -1902,7 +1902,7 @@ impl SabrePayloadBuilder {
             .with_family_version(SABRE_PROTOCOL_VERSION.into())
             .with_inputs(input_addresses)
             .with_outputs(output_addresses)
-            .with_payload_hash_method(HashMethod::SHA512)
+            .with_payload_hash_method(HashMethod::Sha512)
             .with_payload(payload_bytes))
     }
 }
@@ -2347,7 +2347,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2373,7 +2373,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2402,7 +2402,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2428,7 +2428,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2453,7 +2453,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2479,7 +2479,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2505,7 +2505,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2530,7 +2530,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2556,7 +2556,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2584,7 +2584,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     #[test]
@@ -2610,7 +2610,7 @@ mod tests {
             txn_header.family_version(),
             SABRE_PROTOCOL_VERSION.to_string()
         );
-        assert_eq!(txn_header.payload_hash_method(), &HashMethod::SHA512);
+        assert_eq!(txn_header.payload_hash_method(), &HashMethod::Sha512);
     }
 
     fn new_signer() -> Box<dyn Signer> {


### PR DESCRIPTION
Includes changing HashMethod::SHA512 to HashMethod::Sha512.
Transact changed HashMethod enum to follow standard linting practices.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>