### PR TITLE
Switch simple logger to use UTC timestamps

### DIFF
--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/main.rs"
 sawtooth-sdk = "0.5"
 sabre-sdk = {path = "../sdks/rust"}
 log = "0.4"
-simple_logger = "1"
+simple_logger = "1.16"
 clap = "2"
 protobuf = "2.19"
 rust-crypto = "0.2.36"

--- a/tp/src/main.rs
+++ b/tp/src/main.rs
@@ -40,7 +40,10 @@ fn main() {
     );
 
     let matches = app.get_matches();
-    let logger = simple_logger::SimpleLogger::new();
+    let logger = simple_logger::SimpleLogger::new()
+        // Switch to UTC timestamps, as local timestamps are not stable, by default. They are only
+        // available if the compiler flag "unsound_local_offset" has been set.
+        .with_utc_timestamps();
     let logger = match matches.occurrences_of("verbose") {
         0 => logger.with_level(LevelFilter::Warn),
         1 => logger.with_level(LevelFilter::Info),


### PR DESCRIPTION
This change updates simple logger to be configured with UTC timestamps. Local timestamps require a compiler flag, unsound_local_offset, which is required by a transient dependency.  The time crate (the transient
dependency in question) describes this flag as untested, and it fails in certain environments, such as CI.

See https://time-rs.github.io/internal-api/time/index.html#feature-flags for more information
