### PR TITLE
BACKPORT 0-7: Set dotenv-load to true in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set dotenv-load := true
+
 crates := '\
     sdks/rust \
     cli \

--- a/tp/Cargo.toml
+++ b/tp/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/main.rs"
 sawtooth-sdk = "0.5"
 sabre-sdk = {path = "../sdks/rust"}
 log = "0.4"
-simple_logger = "1"
+simple_logger = "1.16"
 clap = "2"
 protobuf = "2.19"
 rust-crypto = "0.2.36"

--- a/tp/src/main.rs
+++ b/tp/src/main.rs
@@ -29,7 +29,10 @@ fn main() {
         (@arg verbose: -v --verbose +multiple
          "increase output verbosity"))
     .get_matches();
-    let logger = simple_logger::SimpleLogger::new();
+    let logger = simple_logger::SimpleLogger::new()
+        // Switch to UTC timestamps, as local timestamps are not stable, by default. They are only
+        // available if the compiler flag "unsound_local_offset" has been set.
+        .with_utc_timestamps();
     let logger = match matches.occurrences_of("verbose") {
         0 => logger.with_level(LevelFilter::Warn),
         1 => logger.with_level(LevelFilter::Info),


### PR DESCRIPTION
Starting with version 0.11.0, just ignores .env files by default. This
breaks some recipes because we read docker environment variables from
the .env file.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>