### PR TITLE
Fix linting from 1.62

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -589,9 +589,10 @@ fn print_table(table: Vec<Vec<String>>) {
         let mut col_string = String::from("");
         for (i, len) in max_lengths.iter().enumerate() {
             if let Some(value) = row.get(i) {
-                col_string += &format!("{}{} ", value, " ".repeat(*len - value.len()),);
+                col_string.push_str(value);
+                col_string.push_str(&" ".repeat(*len - value.len()));
             } else {
-                col_string += &" ".repeat(*len);
+                col_string.push_str(&" ".repeat(*len));
             }
         }
         println!("{}", col_string);


### PR DESCRIPTION
Addresses clippy lints introduced with Rust 1.62.

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>