### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,12 +4,7 @@
 | Name | GitHub | 
 | --- | --- |
 | Andi Gunderson | agunde406 |
-| Dan Middleton | dcmiddle |
-| James Mitchell | jsmitchell |
-| Logan Seeley | ltseeley |
 | Peter Schwarz | peterschwarz |
-| Richard Berg | rberg2 |
-| Ryan Banks | RyanLassigBanks |
 | Ryan Beck-Buysse | rbuysse |
 | Shawn Amundson | vaporos |
 
@@ -17,3 +12,9 @@
 | Name | GitHub |
 | --- | --- |
 | Adam Ludvik | aludvik |
+| Dan Middleton | dcmiddle |
+| James Mitchell | jsmitchell |
+| Logan Seeley | ltseeley |
+| Richard Berg | rberg2 |
+| Ryan Banks | RyanLassigBanks |
+


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>