### PR TITLE
Retire Logan from maintainers and codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @dcmiddle @jsmitchell @ltseeley @peterschwarz @rberg2 @rbuysse @ryanlassigbanks @vaporos
+*       @agunde406 @dcmiddle @jsmitchell @peterschwarz @rberg2 @rbuysse @ryanlassigbanks @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,6 @@
 | Andi Gunderson | agunde406 |
 | Dan Middleton | dcmiddle |
 | James Mitchell | jsmitchell |
-| Logan Seeley | ltseeley |
 | Peter Schwarz | peterschwarz |
 | Richard Berg | rberg2 |
 | Ryan Banks | RyanLassigBanks |
@@ -17,3 +16,4 @@
 | Name | GitHub |
 | --- | --- |
 | Adam Ludvik | aludvik |
+| Logan Seeley | ltseeley |


### PR DESCRIPTION
They have previously indicated they wished to be retired.